### PR TITLE
PP-15409 Upgrade PACT NPM modules

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -735,7 +735,7 @@
         "filename": "test/pact/adminusers-client/invite/complete-invite.pact.test.js",
         "hashed_secret": "73fab36036653ebf81d45c017039d0be4bc59e64",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 78
       }
     ],
     "test/pact/adminusers-client/invite/create-invite-to-join-service.pact.test.js": [
@@ -762,7 +762,7 @@
         "filename": "test/pact/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js",
         "hashed_secret": "614770647df3ab100b871bfc0d20e72c8625a5c4",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 17
       }
     ],
     "test/pact/adminusers-client/user/assign-servicerole.pact.test.js": [
@@ -816,7 +816,7 @@
         "filename": "test/pact/connector-client/connector-get-charge.pact.test.js",
         "hashed_secret": "d5662d7353c6257f68cab2a3b0f758cc79b1ac5e",
         "is_verified": false,
-        "line_number": 76
+        "line_number": 80
       }
     ],
     "test/pact/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js": [
@@ -838,5 +838,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-14T12:58:00Z"
+  "generated_at": "2026-05-29T16:39:32Z"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,9 @@
         "@cypress/webpack-preprocessor": "^6.0.2",
         "@eslint/js": "^9.23.0",
         "@govuk-pay/run-amock": "0.0.13",
-        "@pact-foundation/pact": "^12.1.1",
-        "@pact-foundation/pact-core": "^14.0.5",
+        "@pact-foundation/pact": "^16.5.0",
+        "@pact-foundation/pact-cli": "^18.1.0",
+        "@pact-foundation/pact-core": "^19.2.0",
         "@percy/cli": "^1.31.8",
         "@percy/cypress": "^3.1.7",
         "@types/chai": "^5.2.2",
@@ -3918,40 +3919,150 @@
       }
     },
     "node_modules/@pact-foundation/pact": {
-      "version": "12.5.2",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-12.5.2.tgz",
-      "integrity": "sha512-1628OG8dHOP2++Clw87SL+9KBpkjE1tTuu1Ui5NgGXyPTWJ3n1tBkbVJTUSwlLbBXhig8ZuisYlHstmcMAr+2Q==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact/-/pact-16.5.0.tgz",
+      "integrity": "sha512-9YgmU6fDJGQVYoAm2ez52dyKfQwFzW47GlrT8IAKuzjL6qZVZ9+ael6myeMbQqz7J5lzEGLoUi2PMkBFFgQxRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pact-foundation/pact-core": "^14.3.4",
-        "@types/express": "^4.17.11",
-        "axios": "^1.6.1",
-        "body-parser": "^1.20.0",
-        "cli-color": "^2.0.1",
-        "express": "^4.19.2",
-        "graphql": "^14.0.0",
-        "graphql-tag": "^2.9.1",
+        "@pact-foundation/pact-core": "^19.2.0",
+        "axios": "^1.12.2",
+        "body-parser": "^2.2.0",
+        "chalk": "4.1.2",
+        "express": "^5.1.0",
+        "graphql": "^16.11.0",
+        "graphql-tag": "^2.12.6",
         "http-proxy": "^1.18.1",
-        "https-proxy-agent": "^7.0.4",
-        "js-base64": "^3.6.1",
+        "https-proxy-agent": "^9.0.0",
+        "js-base64": "^3.7.8",
         "lodash": "^4.17.21",
-        "lodash.isfunction": "3.0.8",
-        "lodash.isnil": "4.0.0",
-        "lodash.isundefined": "3.0.1",
-        "lodash.omit": "^4.5.0",
-        "pkginfo": "^0.4.1",
-        "ramda": "^0.30.0",
-        "randexp": "^0.5.3"
+        "ramda": "^0.32.0",
+        "randexp": "^0.5.3",
+        "router": "^2.2.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@pact-foundation/pact-cli": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli/-/pact-cli-18.1.0.tgz",
+      "integrity": "sha512-lDm8BNvfma5YxB36IEmgOsQ5yO2XHRjsSKyO0R1Vh65j5Jl5rOdpVDElYYQ/ry4/tmky88oEbuOtEHkBLC8VHA==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "pact": "bin/pact.js",
+        "pact-broker": "bin/pact-broker.js",
+        "pact-mock-server": "bin/pact-mock-server.js",
+        "pact-plugin": "bin/pact-plugin.js",
+        "pact-stub-server": "bin/pact-stub-server.js",
+        "pact-verifier": "bin/pact-verifier.js",
+        "pactflow": "bin/pactflow.js"
       },
       "engines": {
         "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@pact-foundation/pact-cli-darwin-arm64": "18.1.0",
+        "@pact-foundation/pact-cli-darwin-x64": "18.1.0",
+        "@pact-foundation/pact-cli-linux-arm64": "18.1.0",
+        "@pact-foundation/pact-cli-linux-x64": "18.1.0",
+        "@pact-foundation/pact-cli-windows-arm64": "18.1.0",
+        "@pact-foundation/pact-cli-windows-x64": "18.1.0"
       }
     },
+    "node_modules/@pact-foundation/pact-cli-darwin-arm64": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-darwin-arm64/-/pact-cli-darwin-arm64-18.1.0.tgz",
+      "integrity": "sha512-RBgBGOmHfdRmd0/LxxCpwGyxvCrVaqYd8tfvo/dpdntUbHolOGexqu4so6lkYEHsyv5H4KudW3cZ6mhUGT68HA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-darwin-x64": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-darwin-x64/-/pact-cli-darwin-x64-18.1.0.tgz",
+      "integrity": "sha512-pVGziqkqPt6tVvDAkaXaAK3zeq3VZm4Hrcprue2F0IZihV4UZBkVE7oQCfnfCt/ft0xQiGKvur1Bq5laJ8Wl0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-linux-arm64": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-linux-arm64/-/pact-cli-linux-arm64-18.1.0.tgz",
+      "integrity": "sha512-O6E63oThAbVDRemNQa9/gb3tE+GWODA6Cd5z0QSJKT5RsABX0KcoWA8mPs6G9E4LWoQwvOZo13jOgd77Lrjusg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-linux-x64": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-linux-x64/-/pact-cli-linux-x64-18.1.0.tgz",
+      "integrity": "sha512-DJ3ntNVIpbhIPXgmaLtRikwZfMI3pBx98qZb3vOJqzKPPcAEuziiYnTcs3ev+dLJOvG/IxBPHfCIwNzyYaXObw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-windows-arm64": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-windows-arm64/-/pact-cli-windows-arm64-18.1.0.tgz",
+      "integrity": "sha512-LetgNiLi5Q1ryfAy/FoKliB9FgGkbGr4DVgC8Zy86/rDpQLtNhOrwY2zQJTZCa1mSfZujQeoVa9J2/SgS716qQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-cli-windows-x64": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-cli-windows-x64/-/pact-cli-windows-x64-18.1.0.tgz",
+      "integrity": "sha512-xMfYGePO3B0a1m9feI1iFKsvCpQR9W9qLdYV0sfoooGugouFGf1fSPiwx73UCw+kozsvvlgUdiQ/hmri1HAavA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@pact-foundation/pact-core": {
-      "version": "14.3.8",
-      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-14.3.8.tgz",
-      "integrity": "sha512-CG1DhuA/ROEgmAaj9DaFnSZ8fpLNoiSgK5QyM9WkFsx5gFoRHBS2g4Gw+s7ZDp9NkoxbMuZ3HCCicXoVPCGUwg==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-19.2.0.tgz",
+      "integrity": "sha512-7EB2e850hmBzGnwOYTRj4TCFCJQa9zaOy53bK+ybzEDx801olf0gVlYqMYHt1EsHUZzmtS5uDybpr9UMcZQxgg==",
       "cpu": [
         "x64",
         "ia32",
@@ -3965,188 +4076,198 @@
         "win32"
       ],
       "dependencies": {
-        "chalk": "4.1.2",
-        "check-types": "7.3.0",
-        "cross-spawn": "7.0.3",
-        "mkdirp": "1.0.0",
-        "needle": "^3.2.0",
+        "check-types": "11.2.3",
+        "detect-libc": "^2.0.3",
         "node-gyp-build": "^4.6.0",
-        "pino": "^8.7.0",
-        "pino-pretty": "^9.1.1",
-        "promise-timeout": "1.3.0",
-        "rimraf": "2.6.2",
-        "underscore": "1.12.1",
-        "unixify": "1.0.0"
-      },
-      "bin": {
-        "pact": "bin/pact.js",
-        "pact-broker": "bin/pact-broker.js",
-        "pact-message": "bin/pact-message.js",
-        "pact-mock-service": "bin/pact-mock-service.js",
-        "pact-provider-verifier": "bin/pact-provider-verifier.js",
-        "pact-stub-service": "bin/pact-stub-service.js",
-        "pactflow": "bin/pactflow.js"
+        "pino": "^10.0.0",
+        "pino-pretty": "^13.1.1",
+        "underscore": "1.13.8"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@pact-foundation/pact-core/node_modules/check-types": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.3.0.tgz",
-      "integrity": "sha512-bzDMlwEIZFtyK70RHwQhMCvXpPyJZgOCCKlvH9oAJz4quUQse8ZynYE5RQzKpY7b5PoL6G+jQMcZzUPD4p6tFg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@pact-foundation/pact/node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@pact-foundation/pact/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@pact-foundation/pact/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "node": ">=20"
       },
+      "optionalDependencies": {
+        "@pact-foundation/pact-core-darwin-arm64": "19.2.0",
+        "@pact-foundation/pact-core-darwin-x64": "19.2.0",
+        "@pact-foundation/pact-core-linux-arm64-glibc": "19.2.0",
+        "@pact-foundation/pact-core-linux-arm64-musl": "19.2.0",
+        "@pact-foundation/pact-core-linux-x64-glibc": "19.2.0",
+        "@pact-foundation/pact-core-linux-x64-musl": "19.2.0",
+        "@pact-foundation/pact-core-windows-x64": "19.2.0"
+      }
+    },
+    "node_modules/@pact-foundation/pact-core-darwin-arm64": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-19.2.0.tgz",
+      "integrity": "sha512-cQvvWfJKS7iMzkunzh/kdgmyVLhAxyr/BQ8fOnMco2M/1+GHR+sOXvhrR1tes+NAYd1xjE3fbg1K2Flno8aDBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-core-darwin-x64": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-19.2.0.tgz",
+      "integrity": "sha512-UltPXDZ+h1r3JqgIpEBP16bQzB90otd1QbcoeM3XakF9khCrYhW4y9llSuaosyqPFYwCk+mLaZTl/4iitJJaow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-core-linux-arm64-glibc": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-19.2.0.tgz",
+      "integrity": "sha512-amiv4COurH1FRa7DSH3ks4UPQCb5J3x4GKrArf8UsTOkNhVGFUWVl83LOELj9Gtk67GwJ96iF7/fQps8I/iFIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-core-linux-arm64-musl": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-19.2.0.tgz",
+      "integrity": "sha512-tGWF7dP72Ho1A1PApyUqUMRI/e+gfbPxfaXxwWMXNh8JLK2jQQnP4bWymGwHQ4vxL7wn8ayx8I5y6x1vk/2+rA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-core-linux-x64-glibc": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-glibc/-/pact-core-linux-x64-glibc-19.2.0.tgz",
+      "integrity": "sha512-/ZNuWKuFJSBRZH09t7FXqKLy5koCaMIZ4RdbockLYlNo8uWF2ALfRCllj+SbXPLK+T+lVnBrs5s94X2cu4Rc7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-core-linux-x64-musl": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-19.2.0.tgz",
+      "integrity": "sha512-n0m39CzVkq8J2alir1redm0rAdUVQzkKJqYBQdRmhEIa+QeGjUrJq+gmakUysoJxfSY4UthnJ9jS8SoyiZ+k6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-core-windows-x64": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-19.2.0.tgz",
+      "integrity": "sha512-WZSDBL1Sn8y5+YJTK+HDiS/Fn9th1M4QJW2dflQ8UFwoaIh6yb0TrJjtuWbDGIwNeD4Sv8CJ5jJOf1nyNjFLfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pact-foundation/pact-core/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=8"
       }
     },
     "node_modules/@pact-foundation/pact/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
-    "node_modules/@pact-foundation/pact/node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+    "node_modules/@pact-foundation/pact/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/@pact-foundation/pact/node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/@pact-foundation/pact/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@pact-foundation/pact/node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@pact-foundation/pact/node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
+        "ms": "^2.1.3"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@pact-foundation/pact/node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@pact-foundation/pact/node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@pact-foundation/pact/node_modules/http-errors": {
       "version": "2.0.1",
@@ -4170,92 +4291,87 @@
       }
     },
     "node_modules/@pact-foundation/pact/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
-    "node_modules/@pact-foundation/pact/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+    "node_modules/@pact-foundation/pact/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/@pact-foundation/pact/node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@pact-foundation/pact/node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+    "node_modules/@pact-foundation/pact/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@pact-foundation/pact/node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@pact-foundation/pact/node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@pact-foundation/pact/node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 0.10"
       }
     },
     "node_modules/@pact-foundation/pact/node_modules/statuses": {
@@ -4266,6 +4382,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -4966,6 +5115,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sentry/core": {
       "version": "6.12.0",
@@ -6651,19 +6807,6 @@
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
       "license": "MIT"
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6931,13 +7074,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -8089,23 +8225,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cli-color": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
-      "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.64",
-        "es6-iterator": "^2.0.3",
-        "memoizee": "^0.4.15",
-        "timers-ext": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/cli-cursor": {
@@ -9973,16 +10092,6 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter2": {
       "version": "6.4.7",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
@@ -10394,9 +10503,9 @@
       "license": "MIT"
     },
     "node_modules/fast-copy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
-      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10437,16 +10546,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -11193,16 +11292,13 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "iterall": "^1.2.2"
-      },
       "engines": {
-        "node": ">= 6.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-tag": {
@@ -11366,15 +11462,11 @@
       }
     },
     "node_modules/help-me": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
-      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^8.0.0",
-        "readable-stream": "^3.6.0"
-      }
+      "license": "MIT"
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -12036,13 +12128,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -12100,9 +12185,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -13016,39 +13101,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.isfunction": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
-      "integrity": "sha512-WQj3vccQSW5IKeRl8F0bezPlZH5/LFXtNPICsbZLsv+HmVfWAfrzy2ZajGqmNLonIjPIcPOk3uXOGv5jgPgTyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnil": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
-      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isundefined": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
-      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
       "dev": true,
       "license": "MIT"
     },
@@ -13541,19 +13597,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.0.tgz",
-      "integrity": "sha512-4Pb+8NJ5DdvaWD797hKOM28wMXsObb4HppQdIwKUHFiB69ICZ4wktOE+qsGGBy7GtwgYNizp0R9KEy4zKYBLMg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mocha": {
       "version": "10.8.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
@@ -13797,36 +13840,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/needle/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -14755,173 +14768,80 @@
       }
     },
     "node_modules/pino": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
-      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^3.0.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.6.0"
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
       }
     },
-    "node_modules/pino-abstract-transport/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/pino-abstract-transport/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/pino-pretty": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-9.4.1.tgz",
-      "integrity": "sha512-loWr5SNawVycvY//hamIzyz3Fh5OSpvkcO13MwdDW+eKIGylobPLqnVGTDwDXkdmpJd1BhEG+qhDw09h6SqJiQ==",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.7",
         "dateformat": "^4.6.3",
-        "fast-copy": "^3.0.0",
+        "fast-copy": "^4.0.0",
         "fast-safe-stringify": "^2.1.1",
-        "help-me": "^4.0.1",
+        "help-me": "^5.0.0",
         "joycon": "^3.1.1",
         "minimist": "^1.2.6",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.0.0",
+        "pino-abstract-transport": "^3.0.0",
         "pump": "^3.0.0",
-        "readable-stream": "^4.0.0",
-        "secure-json-parse": "^2.4.0",
-        "sonic-boom": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
       },
       "bin": {
         "pino-pretty": "bin.js"
       }
     },
-    "node_modules/pino-pretty/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/pino-pretty/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/pino-pretty/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14936,16 +14856,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/pkginfo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/pngjs": {
@@ -15207,10 +15117,20 @@
       "license": "MIT"
     },
     "node_modules/process-warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/prom-client": {
@@ -15224,13 +15144,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/promise-timeout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
-      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/propagate": {
       "version": "2.0.1",
@@ -15543,9 +15456,9 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.32.0.tgz",
+      "integrity": "sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -15875,13 +15788,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -16013,42 +15919,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/ripemd160": {
       "version": "2.0.2",
@@ -16658,13 +16528,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -16740,10 +16603,20 @@
       "peer": true
     },
     "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
@@ -17258,9 +17131,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17378,6 +17251,29 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/staticify": {
@@ -18157,14 +18053,24 @@
       "license": "MIT"
     },
     "node_modules/thread-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/throng": {
       "version": "5.0.0",
@@ -18609,9 +18515,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -18687,32 +18593,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/unixify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
-      "integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "normalize-path": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unixify/node_modules/normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "remove-trailing-separator": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",
     "cypress:test-percy": "percy exec -- cypress run",
-    "publish-pacts": "./bin/publish-pacts.js"
+    "publish-pacts": "find ./pacts -name '*.json' ! -name '*to-be*' | xargs pact-broker publish --consumer-app-version=$PACT_CONSUMER_VERSION --broker-base-url=$PACT_BROKER_URL --broker-username=$PACT_BROKER_USERNAME --broker-password=$PACT_BROKER_PASSWORD"
   },
   "lint-staged": {
     "*.js": [
@@ -111,8 +111,9 @@
     "@cypress/webpack-preprocessor": "^6.0.2",
     "@eslint/js": "^9.23.0",
     "@govuk-pay/run-amock": "0.0.13",
-    "@pact-foundation/pact": "^12.1.1",
-    "@pact-foundation/pact-core": "^14.0.5",
+    "@pact-foundation/pact": "^16.5.0",
+    "@pact-foundation/pact-cli": "^18.1.0",
+    "@pact-foundation/pact-core": "^19.2.0",
     "@percy/cli": "^1.31.8",
     "@percy/cypress": "^3.1.7",
     "@types/chai": "^5.2.2",

--- a/test/fixtures/charge.fixtures.js
+++ b/test/fixtures/charge.fixtures.js
@@ -1,19 +1,19 @@
 'use strict'
 
-const { string } = require('@pact-foundation/pact').Matchers
+const { string } = require('@pact-foundation/pact').MatchersV2
 
-function validPostChargeRequestRequest (opts = {}) {
+function validPostChargeRequestRequest(opts = {}) {
   return {
     amount: opts.amount || 100,
     reference: opts.reference || 'a reference',
     description: opts.description || 'a description',
     return_url: opts.returnUrl || 'https://somewhere.gov.uk/rainbow/1',
-    credential_id: opts.credential_id
+    credential_id: opts.credential_id,
   }
 }
 
 // this fixture is using matchers (string = type)
-function validPostChargeRequestResponse (opts = {}) {
+function validPostChargeRequestResponse(opts = {}) {
   return {
     charge_id: string('ch-ab2341da231434l'),
     amount: 100,
@@ -22,62 +22,62 @@ function validPostChargeRequestResponse (opts = {}) {
     return_url: opts.returnUrl || 'https://somewhere.gov.uk/rainbow/1',
     state: opts.state || {
       status: 'created',
-      finished: false
+      finished: false,
     },
     links: opts.links || [
       {
         href: string('https://connector.service.backend/v1/api/accounts/42/charges/ch-ab2341da231434l'),
         rel: 'self',
-        method: 'GET'
+        method: 'GET',
       },
       {
         rel: 'refunds',
         href: string('url'),
-        method: 'GET'
+        method: 'GET',
       },
       {
         href: string('http://Frontend/secure/1934c1cb-3337-41bd-9f4d-e5df77604f32'),
         rel: 'next_url',
-        method: 'GET'
+        method: 'GET',
       },
       {
         href: string('http://frontend_connector/charge/'),
         rel: 'next_url_post',
         type: 'application/x-www-form-urlencoded',
         params: {
-          chargeTokenId: string('token_1234567asdf')
+          chargeTokenId: string('token_1234567asdf'),
         },
-        method: 'POST'
-      }
-    ]
+        method: 'POST',
+      },
+    ],
   }
 }
 
-function validGetChargeResponse (opts = {}) {
+function validGetChargeResponse(opts = {}) {
   return {
     state: opts.state || { status: 'started', finished: false },
-    charge_id: opts.chargeId || 'ht439nfg2l1e303k0dmifrn4fc'
+    charge_id: opts.chargeId || 'ht439nfg2l1e303k0dmifrn4fc',
   }
 }
 
-function validGetChargeResponseWithExemption (opts = {}) {
+function validGetChargeResponseWithExemption(opts = {}) {
   return {
     state: opts.state || { status: 'started', finished: false },
     charge_id: opts.chargeId || 'ch_123abc456def',
     exemption: opts.exemption || { requested: true, type: 'corporate', outcome: { result: 'honoured' } },
-    authorisation_summary: opts.authorisation_summary || { three_d_secure: { required: true, version: '2.1.0' } }
+    authorisation_summary: opts.authorisation_summary || { three_d_secure: { required: true, version: '2.1.0' } },
   }
 }
 
-function validGetChargeResponseWithAuthSummary (opts = {}) {
+function validGetChargeResponseWithAuthSummary(opts = {}) {
   return {
     state: opts.state || { status: 'started', finished: false },
     charge_id: opts.chargeId || 'ch_123abc456def',
-    authorisation_summary: opts.authorisation_summary || { three_d_secure: { required: true, version: '2.1.0' } }
+    authorisation_summary: opts.authorisation_summary || { three_d_secure: { required: true, version: '2.1.0' } },
   }
 }
 
-function validChargeResponse (opts = {}) {
+function validChargeResponse(opts = {}) {
   return {
     amount: opts.amount || 200,
     state: opts.state || { status: 'started', finished: false },
@@ -88,17 +88,17 @@ function validChargeResponse (opts = {}) {
       status: 'pending',
       user_external_id: null,
       amount_available: 200,
-      amount_submitted: 0
+      amount_submitted: 0,
     },
     settlement_summary: opts.settlementSummary || {
       capture_submit_time: opts.captureSubmitTime || null,
-      captured_date: opts.capturedDate || null
+      captured_date: opts.capturedDate || null,
     },
     authorisation_summary: opts.authorisationSummary || {
       three_d_secure: {
-        required: false
-      }
-    }
+        required: false,
+      },
+    },
   }
 }
 
@@ -108,5 +108,5 @@ module.exports = {
   validPostChargeRequestResponse,
   validGetChargeResponse,
   validGetChargeResponseWithExemption,
-  validGetChargeResponseWithAuthSummary
+  validGetChargeResponseWithAuthSummary,
 }

--- a/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/authenticate/authenticate.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/forgotten-password/create-forgotten-password.pact.test.js
+++ b/test/pact/adminusers-client/forgotten-password/create-forgotten-password.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/forgotten-password/get-forgotten-password.pact.test.js
+++ b/test/pact/adminusers-client/forgotten-password/get-forgotten-password.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/invite/complete-invite.pact.test.js
+++ b/test/pact/adminusers-client/invite/complete-invite.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -26,7 +26,7 @@ describe('adminusers client - complete an invite', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -41,29 +41,34 @@ describe('adminusers client - complete an invite', function () {
 
     const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest(secondFactorMethod.APP)
     const validInviteCompleteResponse = inviteFixtures.inviteCompleteResponseWithNoServiceExternalId({
-      user_external_id: userExternalId
+      user_external_id: userExternalId,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
-          .withState('a valid self-signup invite exists with invite code an-invite-code')
-          .withUponReceiving('a valid request to complete a self-signup invite')
-          .withMethod('POST')
-          .withRequestBody(validInviteCompleteRequest)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validInviteCompleteResponse))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
+            .withState('a valid self-signup invite exists with invite code an-invite-code')
+            .withUponReceiving('a valid request to complete a self-signup invite')
+            .withMethod('POST')
+            .withRequestBody(validInviteCompleteRequest)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validInviteCompleteResponse))
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminUsersClient.completeInvite(inviteCode, secondFactorMethod.APP).should.be.fulfilled.then(response => {
-        expect(response.user_external_id).to.equal(userExternalId)
-      }).should.notify(done)
+      adminUsersClient
+        .completeInvite(inviteCode, secondFactorMethod.APP)
+        .should.be.fulfilled.then((response) => {
+          expect(response.user_external_id).to.equal(userExternalId)
+        })
+        .should.notify(done)
     })
   })
 
@@ -75,30 +80,35 @@ describe('adminusers client - complete an invite', function () {
     const validInviteCompleteRequest = inviteFixtures.validInviteCompleteRequest(secondFactorMethod.APP)
     const validInviteCompleteResponse = inviteFixtures.validInviteCompleteResponse({
       user_external_id: userExternalId,
-      service_external_id: serviceExternalId
+      service_external_id: serviceExternalId,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
-          .withState('a valid invite to add a user to a service exists with invite code an-invite-code')
-          .withUponReceiving('a valid request to complete an invite to add a user to a service')
-          .withMethod('POST')
-          .withRequestBody(validInviteCompleteRequest)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validInviteCompleteResponse))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
+            .withState('a valid invite to add a user to a service exists with invite code an-invite-code')
+            .withUponReceiving('a valid request to complete an invite to add a user to a service')
+            .withMethod('POST')
+            .withRequestBody(validInviteCompleteRequest)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validInviteCompleteResponse))
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminUsersClient.completeInvite(inviteCode, secondFactorMethod.APP).should.be.fulfilled.then(response => {
-        expect(response.user_external_id).to.equal(userExternalId)
-        expect(response.service_external_id).to.equal(serviceExternalId)
-      }).should.notify(done)
+      adminUsersClient
+        .completeInvite(inviteCode, secondFactorMethod.APP)
+        .should.be.fulfilled.then((response) => {
+          expect(response.user_external_id).to.equal(userExternalId)
+          expect(response.service_external_id).to.equal(serviceExternalId)
+        })
+        .should.notify(done)
     })
   })
 
@@ -109,30 +119,35 @@ describe('adminusers client - complete an invite', function () {
 
     const validInviteCompleteResponse = inviteFixtures.validInviteCompleteResponse({
       user_external_id: userExternalId,
-      service_external_id: serviceExternalId
+      service_external_id: serviceExternalId,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
-          .withState('an invite to add an existing user to a service exists with invite code an-invite-code')
-          .withUponReceiving('a valid request to complete an invite to add an existing user to a service')
-          .withMethod('POST')
-          .withRequestBody(null)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validInviteCompleteResponse))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/complete`)
+            .withState('an invite to add an existing user to a service exists with invite code an-invite-code')
+            .withUponReceiving('a valid request to complete an invite to add an existing user to a service')
+            .withMethod('POST')
+            .withRequestBody(null)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validInviteCompleteResponse))
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('should complete a service invite successfully', function (done) {
-      adminUsersClient.completeInvite(inviteCode).should.be.fulfilled.then(response => {
-        expect(response.user_external_id).to.equal(userExternalId)
-        expect(response.service_external_id).to.equal(serviceExternalId)
-      }).should.notify(done)
+      adminUsersClient
+        .completeInvite(inviteCode)
+        .should.be.fulfilled.then((response) => {
+          expect(response.user_external_id).to.equal(userExternalId)
+          expect(response.service_external_id).to.equal(serviceExternalId)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/invite/create-invite-to-join-service.pact.test.js
+++ b/test/pact/adminusers-client/invite/create-invite-to-join-service.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/invite/create-self-registration-invite.pact.test.js
+++ b/test/pact/adminusers-client/invite/create-self-registration-invite.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -20,7 +20,7 @@ describe('adminusers client - create self-registration invite', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -34,23 +34,28 @@ describe('adminusers client - create self-registration invite', function () {
     const response = inviteFixtures.validInviteResponse({ ...validCreateInviteRequest })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${INVITES_PATH}`)
-          .withUponReceiving('a valid create self-registration invite request')
-          .withMethod('POST')
-          .withRequestBody(validCreateInviteRequest)
-          .withStatusCode(201)
-          .withResponseBody(pactify(response))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${INVITES_PATH}`)
+            .withUponReceiving('a valid create self-registration invite request')
+            .withMethod('POST')
+            .withRequestBody(validCreateInviteRequest)
+            .withStatusCode(201)
+            .withResponseBody(pactify(response))
+            .build()
+        )
+        .then(() => done())
     })
 
     afterEach(() => provider.verify())
 
     it('should create a invite successfully', function (done) {
-      adminUsersClient.createSelfSignupInvite(validCreateInviteRequest.email).should.be.fulfilled.then(function (inviteResponse) {
-        expect(inviteResponse.email).to.be.equal(validCreateInviteRequest.email)
-      }).should.notify(done)
+      adminUsersClient
+        .createSelfSignupInvite(validCreateInviteRequest.email)
+        .should.be.fulfilled.then(function (inviteResponse) {
+          expect(inviteResponse.email).to.be.equal(validCreateInviteRequest.email)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/invite/get-invite.pact.test.js
+++ b/test/pact/adminusers-client/invite/get-invite.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -23,7 +23,7 @@ describe('adminusers client - get an invite', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -36,29 +36,34 @@ describe('adminusers client - get an invite', function () {
     const inviteCode = 'an-invite-code'
 
     const getInviteResponse = inviteFixtures.validInviteResponse({
-      telephone_number: '0123456789'
+      telephone_number: '0123456789',
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${INVITES_PATH}/${inviteCode}`)
-          .withState('a valid invite to add a user to a service exists with invite code an-invite-code')
-          .withUponReceiving('a valid get invite request')
-          .withStatusCode(200)
-          .withResponseBody(pactify(getInviteResponse))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${INVITES_PATH}/${inviteCode}`)
+            .withState('a valid invite to add a user to a service exists with invite code an-invite-code')
+            .withUponReceiving('a valid get invite request')
+            .withStatusCode(200)
+            .withResponseBody(pactify(getInviteResponse))
+            .build()
+        )
+        .then(() => done())
     })
 
     afterEach(() => provider.verify())
 
     it('should find an invite successfully', function (done) {
-      adminUsersClient.getValidatedInvite(inviteCode).should.be.fulfilled.then(function (invite) {
-        expect(invite.email).to.be.equal(getInviteResponse.email)
-        expect(invite.telephone_number).to.be.equal(getInviteResponse.telephone_number)
-        expect(invite.is_invite_to_join_service).to.be.equal(getInviteResponse.is_invite_to_join_service)
-        expect(invite.password_set).to.be.equal(getInviteResponse.password_set)
-      }).should.notify(done)
+      adminUsersClient
+        .getValidatedInvite(inviteCode)
+        .should.be.fulfilled.then(function (invite) {
+          expect(invite.email).to.be.equal(getInviteResponse.email)
+          expect(invite.telephone_number).to.be.equal(getInviteResponse.telephone_number)
+          expect(invite.is_invite_to_join_service).to.be.equal(getInviteResponse.is_invite_to_join_service)
+          expect(invite.password_set).to.be.equal(getInviteResponse.password_set)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/invite/reprovision-otp.pact.test.js
+++ b/test/pact/adminusers-client/invite/reprovision-otp.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ describe('adminusers client - re-provision OTP key', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -40,24 +40,29 @@ describe('adminusers client - re-provision OTP key', function () {
     const reprovisionOtpResponse = inviteFixtures.validInviteResponse()
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/reprovision-otp`)
-          .withState('a valid invite to add a user to a service exists with invite code an-invite-code')
-          .withUponReceiving('a valid request to re-provision an OTP key')
-          .withMethod('POST')
-          .withStatusCode(200)
-          .withResponseBody(pactify(reprovisionOtpResponse))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${INVITE_RESOURCE}/${inviteCode}/reprovision-otp`)
+            .withState('a valid invite to add a user to a service exists with invite code an-invite-code')
+            .withUponReceiving('a valid request to re-provision an OTP key')
+            .withMethod('POST')
+            .withStatusCode(200)
+            .withResponseBody(pactify(reprovisionOtpResponse))
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('should re-provision an OTP key successfully', function (done) {
-      adminUsersClient.reprovisionOtp(inviteCode).should.be.fulfilled.then(function (invite) {
-        expect(invite.otp_key).to.be.equal(reprovisionOtpResponse.otp_key)
-      }).should.notify(done)
+      adminUsersClient
+        .reprovisionOtp(inviteCode)
+        .should.be.fulfilled.then(function (invite) {
+          expect(invite.otp_key).to.be.equal(reprovisionOtpResponse.otp_key)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/invite/send-otp.pact.test.js
+++ b/test/pact/adminusers-client/invite/send-otp.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 

--- a/test/pact/adminusers-client/invite/update-invite-password.pact.test.js
+++ b/test/pact/adminusers-client/invite/update-invite-password.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -21,7 +21,7 @@ describe('adminusers client - update invite password', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,15 +37,17 @@ describe('adminusers client - update invite password', function () {
     const validUpdateInvitePasswordRequest = inviteFixtures.validUpdateInvitePasswordRequest(password)
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/invites/${inviteCode}`)
-          .withState('a valid self-signup invite exists with invite code an-invite-code')
-          .withUponReceiving('a valid request to update the password for an invite')
-          .withMethod('PATCH')
-          .withRequestBody(validUpdateInvitePasswordRequest)
-          .withStatusCode(200)
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`/v1/api/invites/${inviteCode}`)
+            .withState('a valid self-signup invite exists with invite code an-invite-code')
+            .withUponReceiving('a valid request to update the password for an invite')
+            .withMethod('PATCH')
+            .withRequestBody(validUpdateInvitePasswordRequest)
+            .withStatusCode(200)
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 

--- a/test/pact/adminusers-client/invite/update-invite-phone-number.pact.test.js
+++ b/test/pact/adminusers-client/invite/update-invite-phone-number.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -21,7 +21,7 @@ describe('adminusers client - update invite phone number', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,15 +37,17 @@ describe('adminusers client - update invite phone number', function () {
     const validUpdateInvitePhoneNumberRequest = inviteFixtures.validUpdateInvitePhoneNumberRequest(phoneNumber)
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/invites/${inviteCode}`)
-          .withState('a valid self-signup invite exists with invite code an-invite-code')
-          .withUponReceiving('a valid request to update the phone number for an invite')
-          .withMethod('PATCH')
-          .withRequestBody(validUpdateInvitePhoneNumberRequest)
-          .withStatusCode(200)
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`/v1/api/invites/${inviteCode}`)
+            .withState('a valid self-signup invite exists with invite code an-invite-code')
+            .withUponReceiving('a valid request to update the phone number for an invite')
+            .withMethod('PATCH')
+            .withRequestBody(validUpdateInvitePhoneNumberRequest)
+            .withStatusCode(200)
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 

--- a/test/pact/adminusers-client/invite/verify-service-otp-code.pact.test.js
+++ b/test/pact/adminusers-client/invite/verify-service-otp-code.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
@@ -20,7 +20,7 @@ describe('adminusers client - validate otp code for a service', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -33,23 +33,24 @@ describe('adminusers client - validate otp code for a service', function () {
     const validRequest = registrationFixtures.validVerifyOtpCodeRequest({ code: 'aValidCode' })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
-          .withState('a service invite exists with the given code')
-          .withUponReceiving('a valid service otp code submission')
-          .withMethod('POST')
-          .withRequestBody(validRequest)
-          .withStatusCode(200)
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
+            .withState('a service invite exists with the given code')
+            .withUponReceiving('a valid service otp code submission')
+            .withMethod('POST')
+            .withRequestBody(validRequest)
+            .withStatusCode(200)
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('should verify invite otp code successfully', function (done) {
-      adminUsersClient.verifyOtpForInvite(validRequest.code, validRequest.otp).should.be.fulfilled
-        .should.notify(done)
+      adminUsersClient.verifyOtpForInvite(validRequest.code, validRequest.otp).should.be.fulfilled.should.notify(done)
     })
   })
 
@@ -59,25 +60,30 @@ describe('adminusers client - validate otp code for a service', function () {
     const errorResponse = registrationFixtures.badRequestResponseWhenFieldsMissing(['code'])
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
-          .withUponReceiving('a verify service otp code request with missing code')
-          .withMethod('POST')
-          .withRequestBody(verifyCodeRequest)
-          .withStatusCode(400)
-          .withResponseBody(pactify(errorResponse))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
+            .withUponReceiving('a verify service otp code request with missing code')
+            .withMethod('POST')
+            .withRequestBody(verifyCodeRequest)
+            .withStatusCode(400)
+            .withResponseBody(pactify(errorResponse))
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('should return 400 on missing fields', function (done) {
-      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (err) {
-        expect(err.errorCode).to.equal(400)
-        expect(err.message).to.equal('Field [code] is required')
-      }).should.notify(done)
+      adminUsersClient
+        .verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp)
+        .should.be.rejected.then(function (err) {
+          expect(err.errorCode).to.equal(400)
+          expect(err.message).to.equal('Field [code] is required')
+        })
+        .should.notify(done)
     })
   })
 
@@ -85,23 +91,28 @@ describe('adminusers client - validate otp code for a service', function () {
     const verifyCodeRequest = registrationFixtures.validVerifyOtpCodeRequest()
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
-          .withUponReceiving('a verify service otp code request with non existent code')
-          .withMethod('POST')
-          .withRequestBody(verifyCodeRequest)
-          .withStatusCode(404)
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
+            .withUponReceiving('a verify service otp code request with non existent code')
+            .withMethod('POST')
+            .withRequestBody(verifyCodeRequest)
+            .withStatusCode(404)
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('should return 404 if code cannot be found', function (done) {
-      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(404)
-      }).should.notify(done)
+      adminUsersClient
+        .verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp)
+        .should.be.rejected.then(function (response) {
+          expect(response.errorCode).to.equal(404)
+        })
+        .should.notify(done)
     })
   })
 
@@ -109,23 +120,28 @@ describe('adminusers client - validate otp code for a service', function () {
     const verifyCodeRequest = registrationFixtures.validVerifyOtpCodeRequest()
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
-          .withUponReceiving('a service registration details submission for locked code')
-          .withMethod('POST')
-          .withRequestBody(verifyCodeRequest)
-          .withStatusCode(410)
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${OTP_VALIDATE_RESOURCE}`)
+            .withUponReceiving('a service registration details submission for locked code')
+            .withMethod('POST')
+            .withRequestBody(verifyCodeRequest)
+            .withStatusCode(410)
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
     it('return 410 if code locked', function (done) {
-      adminUsersClient.verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(410)
-      }).should.notify(done)
+      adminUsersClient
+        .verifyOtpForInvite(verifyCodeRequest.code, verifyCodeRequest.otp)
+        .should.be.rejected.then(function (response) {
+          expect(response.errorCode).to.equal(410)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
+++ b/test/pact/adminusers-client/service/add-gateway-accounts-to-services.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -29,7 +29,7 @@ describe('admin users client - add gateway accounts to service', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -41,19 +41,20 @@ describe('admin users client - add gateway accounts to service', () => {
   describe('a successful add gateway account to service request', () => {
     const gatewayAccountsIdsToAdd = ['42']
     const gatewayAccountIdsAfter = ['42', '111']
-    before(done => {
+    before((done) => {
       request = serviceFixtures.addGatewayAccountsRequest(gatewayAccountsIdsToAdd)
       const response = serviceFixtures.validServiceResponse({ gateway_account_ids: gatewayAccountIdsAfter })
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
-          .withUponReceiving('a valid request to add a gateway account to a service')
-          .withState(`a service exists with external id ${serviceExternalId} with gateway account with id 111`)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(200)
-          .withResponseBody(pactify(response))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+            .withUponReceiving('a valid request to add a gateway account to a service')
+            .withState(`a service exists with external id ${serviceExternalId} with gateway account with id 111`)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(200)
+            .withResponseBody(pactify(response))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -64,30 +65,33 @@ describe('admin users client - add gateway accounts to service', () => {
       result = adminUsersClient.addGatewayAccountsToService(serviceExternalId, gatewayAccountsIdsToAdd)
 
       return expect(result)
-        .to.be.fulfilled
-        .and.to.eventually.include({ externalId: serviceExternalId })
-        .and.to.have.property('gatewayAccountIds').to.include(...gatewayAccountIdsAfter)
+        .to.be.fulfilled.and.to.eventually.include({ externalId: serviceExternalId })
+        .and.to.have.property('gatewayAccountIds')
+        .to.include(...gatewayAccountIdsAfter)
     })
   })
 
   describe('an unsuccessful add gateway account to service request that responds with 409', () => {
     const gatewayAccountIds = ['111']
-    before(done => {
+    before((done) => {
       request = serviceFixtures.addGatewayAccountsRequest(gatewayAccountIds)
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
-          .withUponReceiving('a invalid request to add a gateway account to a service with a conflicting gateway account id')
-          .withState(`a service exists with external id ${serviceExternalId} with gateway account with id 111`)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(409)
-          .withResponseBody({
-            errors: [
-              'One or more of the following gateway account ids has already assigned to another service: [111]'
-            ]
-          })
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+            .withUponReceiving(
+              'a invalid request to add a gateway account to a service with a conflicting gateway account id'
+            )
+            .withState(`a service exists with external id ${serviceExternalId} with gateway account with id 111`)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(409)
+            .withResponseBody({
+              errors: [
+                'One or more of the following gateway account ids has already assigned to another service: [111]',
+              ],
+            })
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -97,11 +101,12 @@ describe('admin users client - add gateway accounts to service', () => {
     it('should reject with an error detailing the conflicting', () => {
       result = adminUsersClient.addGatewayAccountsToService(serviceExternalId, gatewayAccountIds)
 
-      return expect(result)
-        .to.be.rejected.then(err => {
-          expect(err.errorCode).to.equal(409)
-          expect(err.message).to.equal('One or more of the following gateway account ids has already assigned to another service: [111]')
-        })
+      return expect(result).to.be.rejected.then((err) => {
+        expect(err.errorCode).to.equal(409)
+        expect(err.message).to.equal(
+          'One or more of the following gateway account ids has already assigned to another service: [111]'
+        )
+      })
     })
   })
 
@@ -109,17 +114,20 @@ describe('admin users client - add gateway accounts to service', () => {
     const nonExistentServiceId = 'non-existent-id'
     const gatewayAccountIds = ['42']
 
-    before(done => {
+    before((done) => {
       request = serviceFixtures.addGatewayAccountsRequest(gatewayAccountIds)
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${nonExistentServiceId}`)
-          .withUponReceiving('a invalid request to add a gateway account to a service with a non-extant service external id')
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(404)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${nonExistentServiceId}`)
+            .withUponReceiving(
+              'a invalid request to add a gateway account to a service with a non-extant service external id'
+            )
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(404)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -129,9 +137,7 @@ describe('admin users client - add gateway accounts to service', () => {
     it('should reject with an error detailing the conflicting', () => {
       result = adminUsersClient.addGatewayAccountsToService(nonExistentServiceId, gatewayAccountIds)
 
-      return expect(result)
-        .to.be.rejected
-        .and.to.eventually.have.property('errorCode').to.equal(404)
+      return expect(result).to.be.rejected.and.to.eventually.have.property('errorCode').to.equal(404)
     })
   })
 })

--- a/test/pact/adminusers-client/service/create-service.pact.test.js
+++ b/test/pact/adminusers-client/service/create-service.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ describe('adminusers client - create a new service', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -41,19 +41,20 @@ describe('adminusers client - create a new service', function () {
     const validCreateServiceResponse = serviceFixtures.validServiceResponse({
       name,
       external_id: externalId,
-      gateway_account_ids: gatewayAccountIds
+      gateway_account_ids: gatewayAccountIds,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(SERVICE_RESOURCE)
-          .withUponReceiving('a valid create service request with empty object')
-          .withMethod('POST')
-          .withRequestBody({})
-          .withStatusCode(201)
-          .withResponseBody(pactify(validCreateServiceResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(SERVICE_RESOURCE)
+            .withUponReceiving('a valid create service request with empty object')
+            .withMethod('POST')
+            .withRequestBody({})
+            .withStatusCode(201)
+            .withResponseBody(pactify(validCreateServiceResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -61,11 +62,14 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminUsersClient.createService().should.be.fulfilled.then(service => {
-        expect(service.externalId).to.equal(externalId)
-        expect(service.name).to.equal(name)
-        expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)
-      }).should.notify(done)
+      adminUsersClient
+        .createService()
+        .should.be.fulfilled.then((service) => {
+          expect(service.externalId).to.equal(externalId)
+          expect(service.name).to.equal(name)
+          expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)
+        })
+        .should.notify(done)
     })
   })
 
@@ -76,19 +80,20 @@ describe('adminusers client - create a new service', function () {
     const validCreateServiceResponse = serviceFixtures.validServiceResponse({
       name,
       external_id: externalId,
-      gateway_account_ids: []
+      gateway_account_ids: [],
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(SERVICE_RESOURCE)
-          .withUponReceiving('a valid create service request with gateway account ids')
-          .withMethod('POST')
-          .withRequestBody(validRequest)
-          .withStatusCode(201)
-          .withResponseBody(pactify(validCreateServiceResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(SERVICE_RESOURCE)
+            .withUponReceiving('a valid create service request with gateway account ids')
+            .withMethod('POST')
+            .withRequestBody(validRequest)
+            .withStatusCode(201)
+            .withResponseBody(pactify(validCreateServiceResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -96,10 +101,13 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminUsersClient.createService(null, null).should.be.fulfilled.then(service => {
-        expect(service.externalId).to.equal(externalId)
-        expect(service.name).to.equal(name)
-      }).should.notify(done)
+      adminUsersClient
+        .createService(null, null)
+        .should.be.fulfilled.then((service) => {
+          expect(service.externalId).to.equal(externalId)
+          expect(service.name).to.equal(name)
+        })
+        .should.notify(done)
     })
   })
 
@@ -109,25 +117,26 @@ describe('adminusers client - create a new service', function () {
     const gatewayAccountIds = []
     const validRequest = serviceFixtures.validCreateServiceRequest({
       service_name: {
-        en: name
-      }
+        en: name,
+      },
     })
     const validCreateServiceResponse = serviceFixtures.validServiceResponse({
       name,
       external_id: externalId,
-      gateway_account_ids: gatewayAccountIds
+      gateway_account_ids: gatewayAccountIds,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(SERVICE_RESOURCE)
-          .withUponReceiving('a valid create service request with service name')
-          .withMethod('POST')
-          .withRequestBody(validRequest)
-          .withStatusCode(201)
-          .withResponseBody(pactify(validCreateServiceResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(SERVICE_RESOURCE)
+            .withUponReceiving('a valid create service request with service name')
+            .withMethod('POST')
+            .withRequestBody(validRequest)
+            .withStatusCode(201)
+            .withResponseBody(pactify(validCreateServiceResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -135,11 +144,14 @@ describe('adminusers client - create a new service', function () {
     afterEach(() => provider.verify())
 
     it('should create a new service', function (done) {
-      adminUsersClient.createService('Service name', null, null).should.be.fulfilled.then(service => {
-        expect(service.externalId).to.equal(externalId)
-        expect(service.name).to.equal(name)
-        expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)
-      }).should.notify(done)
+      adminUsersClient
+        .createService('Service name', null, null)
+        .should.be.fulfilled.then((service) => {
+          expect(service.externalId).to.equal(externalId)
+          expect(service.name).to.equal(name)
+          expect(service.gatewayAccountIds).to.deep.equal(gatewayAccountIds)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/service/get-service-users.pact.test.js
+++ b/test/pact/adminusers-client/service/get-service-users.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
+++ b/test/pact/adminusers-client/service/govuk-pay-agreement-post-email-address.pact.test.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
 const path = require('path')
 const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../src/services/clients/adminusers.client')
-const validPostGovUkPayAgreementRequest = require('../../../fixtures/go-live-requests.fixture').validPostGovUkPayAgreementRequest
+const validPostGovUkPayAgreementRequest =
+  require('../../../fixtures/go-live-requests.fixture').validPostGovUkPayAgreementRequest
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
@@ -25,7 +26,7 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -38,24 +39,30 @@ describe('adminusers client - post govuk pay agreement - email address', () => {
     const payload = { user_external_id: userExternalId }
     const validGovUkAgreementUserEmailRequest = validPostGovUkPayAgreementRequest(payload)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}/govuk-pay-agreement`)
-          .withUponReceiving('a valid post govuk pay agreement - email address request')
-          .withState(`a user exists with external id ${userExternalId} with admin role for service with id ${serviceExternalId}`)
-          .withMethod('POST')
-          .withRequestBody(validGovUkAgreementUserEmailRequest)
-          .withStatusCode(201)
-          .withResponseHeaders({})
-          .build()
-      )
-        .then(() => { done() })
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}/govuk-pay-agreement`)
+            .withUponReceiving('a valid post govuk pay agreement - email address request')
+            .withState(
+              `a user exists with external id ${userExternalId} with admin role for service with id ${serviceExternalId}`
+            )
+            .withMethod('POST')
+            .withRequestBody(validGovUkAgreementUserEmailRequest)
+            .withStatusCode(201)
+            .withResponseHeaders({})
+            .build()
+        )
+        .then(() => {
+          done()
+        })
     })
 
     afterEach(() => provider.verify())
 
-    it('should post email address successfully', done => {
-      adminUsersClient.addGovUkAgreementEmailAddress(serviceExternalId, userExternalId)
+    it('should post email address successfully', (done) => {
+      adminUsersClient
+        .addGovUkAgreementEmailAddress(serviceExternalId, userExternalId)
         .should.be.fulfilled.should.notify(done)
     })
   })

--- a/test/pact/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
+++ b/test/pact/adminusers-client/service/stripe-agreement-post-ip-address.pact.test.js
@@ -1,13 +1,14 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
 const path = require('path')
 const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
 const getAdminUsersClient = require('../../../../src/services/clients/adminusers.client')
-const validPostStripeAgreementRequest = require('../../../fixtures/go-live-requests.fixture').validPostStripeAgreementRequest
+const validPostStripeAgreementRequest =
+  require('../../../fixtures/go-live-requests.fixture').validPostStripeAgreementRequest
 
 // Constants
 const SERVICE_RESOURCE = '/v1/api/services'
@@ -24,7 +25,7 @@ describe('adminusers client - post stripe agreement - ip address', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -38,25 +39,27 @@ describe('adminusers client - post stripe agreement - ip address', () => {
     const opts = { ip_address: ipAddress }
     const validStripeAgreementRequest = validPostStripeAgreementRequest(opts)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}/stripe-agreement`)
-          .withUponReceiving('a valid post stripe agreement - ip address request')
-          .withState(`a service exists with external id ${serviceExternalId} and go live stage equals to NOT_STARTED`)
-          .withMethod('POST')
-          .withRequestBody(validStripeAgreementRequest)
-          .withStatusCode(201)
-          .withResponseHeaders({})
-          .build()
-      )
-        .then(() => { done() })
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}/stripe-agreement`)
+            .withUponReceiving('a valid post stripe agreement - ip address request')
+            .withState(`a service exists with external id ${serviceExternalId} and go live stage equals to NOT_STARTED`)
+            .withMethod('POST')
+            .withRequestBody(validStripeAgreementRequest)
+            .withStatusCode(201)
+            .withResponseHeaders({})
+            .build()
+        )
+        .then(() => {
+          done()
+        })
     })
 
     afterEach(() => provider.verify())
 
-    it('should post ip address successfully', done => {
-      adminUsersClient.addStripeAgreementIpAddress(serviceExternalId, ipAddress)
-        .should.be.fulfilled.should.notify(done)
+    it('should post ip address successfully', (done) => {
+      adminUsersClient.addStripeAgreementIpAddress(serviceExternalId, ipAddress).should.be.fulfilled.should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/service/update-collect-billing-address.pact.test.js
+++ b/test/pact/adminusers-client/service/update-collect-billing-address.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -26,7 +26,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -36,23 +36,26 @@ describe('adminusers client - patch collect billing address toggle', function ()
   after(() => provider.finalize())
 
   describe('patch collect billing address toggle - disabled', () => {
-    const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({ enabled: false })
+    const validUpdateCollectBillingAddressRequest = serviceFixtures.validCollectBillingAddressToggleRequest({
+      enabled: false,
+    })
     const validUpdateCollectBillingAddressResponse = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
-      collect_billing_address: false
+      collect_billing_address: false,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
-          .withUponReceiving('a valid patch collect billing address toggle (disabled) request')
-          .withState(`a service exists with external id ${serviceExternalId}`)
-          .withMethod('PATCH')
-          .withRequestBody(validUpdateCollectBillingAddressRequest)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validUpdateCollectBillingAddressResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+            .withUponReceiving('a valid patch collect billing address toggle (disabled) request')
+            .withState(`a service exists with external id ${serviceExternalId}`)
+            .withMethod('PATCH')
+            .withRequestBody(validUpdateCollectBillingAddressRequest)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validUpdateCollectBillingAddressResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -60,11 +63,13 @@ describe('adminusers client - patch collect billing address toggle', function ()
     afterEach(() => provider.verify())
 
     it('should toggle successfully', function (done) {
-      adminUsersClient.updateCollectBillingAddress(serviceExternalId, false)
-        .should.be.fulfilled.then(service => {
+      adminUsersClient
+        .updateCollectBillingAddress(serviceExternalId, false)
+        .should.be.fulfilled.then((service) => {
           expect(service.external_id).to.equal(serviceExternalId)
           expect(service.collect_billing_address).to.equal(false)
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/service/update-default-billing-address-country.pact.test.js
+++ b/test/pact/adminusers-client/service/update-default-billing-address-country.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 
 const path = require('path')
@@ -21,7 +21,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -34,7 +34,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
     const request = serviceFixtures.validUpdateDefaultBillingAddressRequest('IE')
     const response = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
-      default_billing_address_country: 'IE'
+      default_billing_address_country: 'IE',
     })
 
     before(() => {
@@ -63,7 +63,7 @@ describe('adminusers client - patch collect billing address toggle', function ()
     const request = serviceFixtures.validUpdateDefaultBillingAddressRequest(null)
     const response = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
-      default_billing_address_country: null
+      default_billing_address_country: null,
     })
 
     before(() => {

--- a/test/pact/adminusers-client/service/update-psp-test-account-stage.pact.test.js
+++ b/test/pact/adminusers-client/service/update-psp-test-account-stage.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -26,7 +26,7 @@ describe('adminusers client - patch psp test account stage', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -40,20 +40,21 @@ describe('adminusers client - patch psp test account stage', function () {
     const validUpdatePspTestAccountStage = serviceFixtures.validUpdatePspTestAccountStage(value)
     const validUpdatePspTestAccountStageResponse = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
-      current_psp_test_account_stage: 'REQUEST_SUBMITTED'
+      current_psp_test_account_stage: 'REQUEST_SUBMITTED',
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
-          .withUponReceiving('a valid patch current psp test account stage')
-          .withState(`a service exists with external id ${serviceExternalId}`)
-          .withMethod('PATCH')
-          .withRequestBody(validUpdatePspTestAccountStage)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validUpdatePspTestAccountStageResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+            .withUponReceiving('a valid patch current psp test account stage')
+            .withState(`a service exists with external id ${serviceExternalId}`)
+            .withMethod('PATCH')
+            .withRequestBody(validUpdatePspTestAccountStage)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validUpdatePspTestAccountStageResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -61,11 +62,13 @@ describe('adminusers client - patch psp test account stage', function () {
     afterEach(() => provider.verify())
 
     it('should update successfully', function (done) {
-      adminUsersClient.updatePspTestAccountStage(serviceExternalId, 'REQUEST_SUBMITTED')
-        .should.be.fulfilled.then(service => {
+      adminUsersClient
+        .updatePspTestAccountStage(serviceExternalId, 'REQUEST_SUBMITTED')
+        .should.be.fulfilled.then((service) => {
           expect(service.externalId).to.equal(serviceExternalId)
           expect(service.currentPspTestAccountStage).to.equal('REQUEST_SUBMITTED')
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/service/update-request-to-go-live-stage.pact.test.js
+++ b/test/pact/adminusers-client/service/update-request-to-go-live-stage.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -26,7 +26,7 @@ describe('adminusers client - patch request to go live stage', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -40,20 +40,21 @@ describe('adminusers client - patch request to go live stage', function () {
     const validUpdateRequestToGoLiveRequest = serviceFixtures.validUpdateRequestToGoLiveRequest(value)
     const validUpdateRequestToGoLiveResponse = serviceFixtures.validServiceResponse({
       external_id: serviceExternalId,
-      current_go_live_stage: 'ENTERED_ORGANISATION_NAME'
+      current_go_live_stage: 'ENTERED_ORGANISATION_NAME',
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
-          .withUponReceiving('a valid patch current go live stage request')
-          .withState(`a service exists with external id ${serviceExternalId}`)
-          .withMethod('PATCH')
-          .withRequestBody(validUpdateRequestToGoLiveRequest)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validUpdateRequestToGoLiveResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${serviceExternalId}`)
+            .withUponReceiving('a valid patch current go live stage request')
+            .withState(`a service exists with external id ${serviceExternalId}`)
+            .withMethod('PATCH')
+            .withRequestBody(validUpdateRequestToGoLiveRequest)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validUpdateRequestToGoLiveResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -61,11 +62,13 @@ describe('adminusers client - patch request to go live stage', function () {
     afterEach(() => provider.verify())
 
     it('should update successfully', function (done) {
-      adminUsersClient.updateCurrentGoLiveStage(serviceExternalId, 'ENTERED_ORGANISATION_NAME')
-        .should.be.fulfilled.then(service => {
+      adminUsersClient
+        .updateCurrentGoLiveStage(serviceExternalId, 'ENTERED_ORGANISATION_NAME')
+        .should.be.fulfilled.then((service) => {
           expect(service.externalId).to.equal(serviceExternalId)
           expect(service.currentGoLiveStage).to.equal('ENTERED_ORGANISATION_NAME')
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/service/update-service-name.pact.test.js
+++ b/test/pact/adminusers-client/service/update-service-name.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('adminusers client - update service name', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -39,26 +39,27 @@ describe('adminusers client - update service name', function () {
   describe('success with en and cy', () => {
     const serviceName = {
       en: 'en-name',
-      cy: 'cy-name'
+      cy: 'cy-name',
     }
     const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequest(serviceName)
     const validUpdateServiceNameResponse = serviceFixtures.validServiceResponse({
       name: serviceName.en,
       external_id: existingServiceExternalId,
-      service_name: serviceName
+      service_name: serviceName,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
-          .withUponReceiving('a valid update service name request with en and cy')
-          .withState(`a service exists with external id ${existingServiceExternalId}`)
-          .withMethod('PATCH')
-          .withRequestBody(validUpdateServiceNameRequest)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validUpdateServiceNameResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
+            .withUponReceiving('a valid update service name request with en and cy')
+            .withState(`a service exists with external id ${existingServiceExternalId}`)
+            .withMethod('PATCH')
+            .withRequestBody(validUpdateServiceNameRequest)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validUpdateServiceNameResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -66,13 +67,15 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should update service name for en and cy', function (done) {
-      adminUsersClient.updateServiceName(existingServiceExternalId, serviceName.en, serviceName.cy)
-        .should.be.fulfilled.then(service => {
+      adminUsersClient
+        .updateServiceName(existingServiceExternalId, serviceName.en, serviceName.cy)
+        .should.be.fulfilled.then((service) => {
           expect(service.external_id).to.equal(existingServiceExternalId)
           expect(service.name).to.equal(serviceName.en)
           expect(service.service_name.en).to.equal(serviceName.en)
           expect(service.service_name.cy).to.equal(serviceName.cy)
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 
@@ -80,27 +83,28 @@ describe('adminusers client - update service name', function () {
     const serviceNameEn = 'en-name'
     const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequest({
       en: serviceNameEn,
-      cy: ''
+      cy: '',
     })
     const validUpdateServiceNameResponse = serviceFixtures.validServiceResponse({
       name: serviceNameEn,
       external_id: existingServiceExternalId,
       service_name: {
-        en: 'en-name'
-      }
+        en: 'en-name',
+      },
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
-          .withUponReceiving('a valid update service name request with empty string for cy name')
-          .withState(`a service exists with external id ${existingServiceExternalId}`)
-          .withMethod('PATCH')
-          .withRequestBody(validUpdateServiceNameRequest)
-          .withStatusCode(200)
-          .withResponseBody(pactify(validUpdateServiceNameResponse))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${existingServiceExternalId}`)
+            .withUponReceiving('a valid update service name request with empty string for cy name')
+            .withState(`a service exists with external id ${existingServiceExternalId}`)
+            .withMethod('PATCH')
+            .withRequestBody(validUpdateServiceNameRequest)
+            .withStatusCode(200)
+            .withResponseBody(pactify(validUpdateServiceNameResponse))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -108,12 +112,14 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should update service name with empty string for cy', function (done) {
-      adminUsersClient.updateServiceName(existingServiceExternalId, serviceNameEn)
-        .should.be.fulfilled.then(service => {
+      adminUsersClient
+        .updateServiceName(existingServiceExternalId, serviceNameEn)
+        .should.be.fulfilled.then((service) => {
           expect(service.external_id).to.equal(existingServiceExternalId)
           expect(service.name).to.equal(serviceNameEn)
           expect(service.service_name.en).to.equal(serviceNameEn)
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 
@@ -121,20 +127,21 @@ describe('adminusers client - update service name', function () {
     const nonExistentServiceExternalId = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     const serviceName = {
       en: 'en-name',
-      cy: 'cy-name'
+      cy: 'cy-name',
     }
     const validUpdateServiceNameRequest = serviceFixtures.validUpdateServiceNameRequest(serviceName)
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${SERVICE_RESOURCE}/${nonExistentServiceExternalId}`)
-          .withUponReceiving('an invalid update service name request - service not found')
-          .withMethod('PATCH')
-          .withRequestBody(validUpdateServiceNameRequest)
-          .withStatusCode(404)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${SERVICE_RESOURCE}/${nonExistentServiceExternalId}`)
+            .withUponReceiving('an invalid update service name request - service not found')
+            .withMethod('PATCH')
+            .withRequestBody(validUpdateServiceNameRequest)
+            .withStatusCode(404)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -142,9 +149,12 @@ describe('adminusers client - update service name', function () {
     afterEach(() => provider.verify())
 
     it('should return not found if service not exist', function (done) {
-      adminUsersClient.updateServiceName(nonExistentServiceExternalId, serviceName.en, serviceName.cy).should.be.rejected.then(response => {
-        expect(response.errorCode).to.equal(404)
-      }).should.notify(done)
+      adminUsersClient
+        .updateServiceName(nonExistentServiceExternalId, serviceName.en, serviceName.cy)
+        .should.be.rejected.then((response) => {
+          expect(response.errorCode).to.equal(404)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/adminusers-client/service/update-service.pact.test.js
+++ b/test/pact/adminusers-client/service/update-service.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -30,7 +30,7 @@ describe('adminusers client - patch request to update service', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -42,14 +42,15 @@ describe('adminusers client - patch request to update service', function () {
   describe('a valid update service patch request to update single field', () => {
     const merchantDetailsName = 'updated-name'
     const validUpdateServiceRequest = new ServiceUpdateRequest()
-      .replace().merchantDetails.name(merchantDetailsName)
+      .replace()
+      .merchantDetails.name(merchantDetailsName)
       .formatPayload()
 
     const validUpdateServiceResponse = serviceFixtures.validServiceResponse({
       external_id: existingServiceExternalId,
       merchant_details: {
-        name: merchantDetailsName
-      }
+        name: merchantDetailsName,
+      },
     })
 
     before(() => {
@@ -61,7 +62,8 @@ describe('adminusers client - patch request to update service', function () {
           .withRequestBody(validUpdateServiceRequest)
           .withStatusCode(200)
           .withResponseBody(pactify(validUpdateServiceResponse))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
@@ -84,25 +86,37 @@ describe('adminusers client - patch request to update service', function () {
       address_country: 'GB',
       telephone_number: '07700 900 982',
       email: 'foo@example.com',
-      url: 'https://www.example.com'
+      url: 'https://www.example.com',
     }
     const currentGoLiveStage = goLiveStage.ENTERED_ORGANISATION_NAME
     const currentPspTestAccountStage = pspTestAccountStage.REQUEST_SUBMITTED
     const takesPaymentsOverPhone = true
 
     const validUpdateServiceRequest = new ServiceUpdateRequest()
-      .replace().merchantDetails.name(merchantDetails.name)
-      .replace().merchantDetails.addressLine1(merchantDetails.address_line1)
-      .replace().merchantDetails.addressLine2(merchantDetails.address_line2)
-      .replace().merchantDetails.addressCity(merchantDetails.address_city)
-      .replace().merchantDetails.addressPostcode(merchantDetails.address_postcode)
-      .replace().merchantDetails.addressCountry(merchantDetails.address_country)
-      .replace().merchantDetails.telephoneNumber(merchantDetails.telephone_number)
-      .replace().merchantDetails.email(merchantDetails.email)
-      .replace().merchantDetails.url(merchantDetails.url)
-      .replace().currentGoLiveStage(currentGoLiveStage)
-      .replace().currentPspTestAccountStage(currentPspTestAccountStage)
-      .replace().takesPaymentsOverPhone(takesPaymentsOverPhone)
+      .replace()
+      .merchantDetails.name(merchantDetails.name)
+      .replace()
+      .merchantDetails.addressLine1(merchantDetails.address_line1)
+      .replace()
+      .merchantDetails.addressLine2(merchantDetails.address_line2)
+      .replace()
+      .merchantDetails.addressCity(merchantDetails.address_city)
+      .replace()
+      .merchantDetails.addressPostcode(merchantDetails.address_postcode)
+      .replace()
+      .merchantDetails.addressCountry(merchantDetails.address_country)
+      .replace()
+      .merchantDetails.telephoneNumber(merchantDetails.telephone_number)
+      .replace()
+      .merchantDetails.email(merchantDetails.email)
+      .replace()
+      .merchantDetails.url(merchantDetails.url)
+      .replace()
+      .currentGoLiveStage(currentGoLiveStage)
+      .replace()
+      .currentPspTestAccountStage(currentPspTestAccountStage)
+      .replace()
+      .takesPaymentsOverPhone(takesPaymentsOverPhone)
       .formatPayload()
 
     const validUpdateServiceResponse = serviceFixtures.validServiceResponse({
@@ -110,7 +124,7 @@ describe('adminusers client - patch request to update service', function () {
       merchant_details: merchantDetails,
       current_go_live_stage: currentGoLiveStage,
       current_psp_test_account_stage: currentPspTestAccountStage,
-      takes_payments_over_phone: takesPaymentsOverPhone
+      takes_payments_over_phone: takesPaymentsOverPhone,
     })
 
     before(() => {
@@ -122,7 +136,8 @@ describe('adminusers client - patch request to update service', function () {
           .withRequestBody(validUpdateServiceRequest)
           .withStatusCode(200)
           .withResponseBody(pactify(validUpdateServiceResponse))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
@@ -146,11 +161,13 @@ describe('adminusers client - patch request to update service', function () {
   })
 
   describe('an invalid update service patch request', () => {
-    const invalidRequest = [{
-      op: 'replace',
-      'non-existent-path': 'foo',
-      value: 'bar'
-    }]
+    const invalidRequest = [
+      {
+        op: 'replace',
+        'non-existent-path': 'foo',
+        value: 'bar',
+      },
+    ]
 
     before(() => {
       return provider.addInteraction(
@@ -160,7 +177,8 @@ describe('adminusers client - patch request to update service', function () {
           .withMethod('PATCH')
           .withRequestBody(invalidRequest)
           .withStatusCode(400)
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())

--- a/test/pact/adminusers-client/user/assign-servicerole.pact.test.js
+++ b/test/pact/adminusers-client/user/assign-servicerole.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/user/authenticate.pact.test.js
+++ b/test/pact/adminusers-client/user/authenticate.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const _ = require('lodash')

--- a/test/pact/adminusers-client/user/delete-user.pact.test.js
+++ b/test/pact/adminusers-client/user/delete-user.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/user/get-multiple-users.pact.test.js
+++ b/test/pact/adminusers-client/user/get-multiple-users.pact.test.js
@@ -1,5 +1,5 @@
 'use strict'
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/user/get-user.pact.test.js
+++ b/test/pact/adminusers-client/user/get-user.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const { expect } = chai

--- a/test/pact/adminusers-client/user/increment-session-version.pact.test.js
+++ b/test/pact/adminusers-client/user/increment-session-version.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/user/second-factor.pact.test.js
+++ b/test/pact/adminusers-client/user/second-factor.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/user/update-password.pact.test.js
+++ b/test/pact/adminusers-client/user/update-password.pact.test.js
@@ -1,4 +1,4 @@
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/pact/adminusers-client/user/update-servicerole.pact.test.ts
+++ b/test/pact/adminusers-client/user/update-servicerole.pact.test.ts
@@ -1,4 +1,4 @@
-import { Pact } from '@pact-foundation/pact'
+import { PactV2 as Pact } from '@pact-foundation/pact'
 import path from 'path'
 import chai from 'chai'
 import userFixtures from '@test/fixtures/user.fixtures'

--- a/test/pact/connector-client/connector-client-create-gateway-account.pact.test.js
+++ b/test/pact/connector-client/connector-client-create-gateway-account.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -24,7 +24,7 @@ describe('connector client - create gateway account', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,14 +37,15 @@ describe('connector client - create gateway account', function () {
     const validCreateGatewayAccountRequest = gatewayAccountFixtures.validCreateGatewayAccountRequest()
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(ACCOUNTS_RESOURCE)
-          .withUponReceiving('a valid create gateway account request')
-          .withMethod('POST')
-          .withRequestBody(validCreateGatewayAccountRequest)
-          .withStatusCode(201)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(ACCOUNTS_RESOURCE)
+            .withUponReceiving('a valid create gateway account request')
+            .withMethod('POST')
+            .withRequestBody(validCreateGatewayAccountRequest)
+            .withStatusCode(201)
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -52,15 +53,17 @@ describe('connector client - create gateway account', function () {
     afterEach(() => provider.verify())
 
     it('should submit create gateway account successfully', function (done) {
-      connectorClient.createGatewayAccount(
-        validCreateGatewayAccountRequest.payment_provider,
-        validCreateGatewayAccountRequest.type,
-        validCreateGatewayAccountRequest.service_name,
-        validCreateGatewayAccountRequest.analytics_id,
-        validCreateGatewayAccountRequest.service_id,
-        validCreateGatewayAccountRequest.send_payer_email_to_gateway,
-        validCreateGatewayAccountRequest.send_payer_ip_address_to_gateway
-      ).should.be.fulfilled.should.notify(done)
+      connectorClient
+        .createGatewayAccount(
+          validCreateGatewayAccountRequest.payment_provider,
+          validCreateGatewayAccountRequest.type,
+          validCreateGatewayAccountRequest.service_name,
+          validCreateGatewayAccountRequest.analytics_id,
+          validCreateGatewayAccountRequest.service_id,
+          validCreateGatewayAccountRequest.send_payer_email_to_gateway,
+          validCreateGatewayAccountRequest.send_payer_ip_address_to_gateway
+        )
+        .should.be.fulfilled.should.notify(done)
     })
   })
 
@@ -68,19 +71,20 @@ describe('connector client - create gateway account', function () {
     const invalidCreateGatewayAccountRequest = gatewayAccountFixtures.validCreateGatewayAccountRequest()
     invalidCreateGatewayAccountRequest.payment_provider = 'non-existent-payment-provider'
     const errorResponse = {
-      message: ['Unsupported payment provider value.']
+      message: ['Unsupported payment provider value.'],
     }
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(ACCOUNTS_RESOURCE)
-          .withUponReceiving('an invalid create gateway account request')
-          .withMethod('POST')
-          .withRequestBody(invalidCreateGatewayAccountRequest)
-          .withStatusCode(422)
-          .withResponseBody(errorResponse)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(ACCOUNTS_RESOURCE)
+            .withUponReceiving('an invalid create gateway account request')
+            .withMethod('POST')
+            .withRequestBody(invalidCreateGatewayAccountRequest)
+            .withStatusCode(422)
+            .withResponseBody(errorResponse)
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -88,18 +92,21 @@ describe('connector client - create gateway account', function () {
     afterEach(() => provider.verify())
 
     it('should return 422 for unsupported payment provider', function (done) {
-      connectorClient.createGatewayAccount(
-        invalidCreateGatewayAccountRequest.payment_provider,
-        invalidCreateGatewayAccountRequest.type,
-        invalidCreateGatewayAccountRequest.service_name,
-        invalidCreateGatewayAccountRequest.analytics_id,
-        invalidCreateGatewayAccountRequest.service_id,
-        invalidCreateGatewayAccountRequest.send_payer_email_to_gateway,
-        invalidCreateGatewayAccountRequest.send_payer_ip_address_to_gateway
-      ).should.be.rejected.then(function (response) {
-        expect(response.errorCode).to.equal(422)
-        expect(response.message).to.equal(errorResponse.message[0])
-      }).should.notify(done)
+      connectorClient
+        .createGatewayAccount(
+          invalidCreateGatewayAccountRequest.payment_provider,
+          invalidCreateGatewayAccountRequest.type,
+          invalidCreateGatewayAccountRequest.service_name,
+          invalidCreateGatewayAccountRequest.analytics_id,
+          invalidCreateGatewayAccountRequest.service_id,
+          invalidCreateGatewayAccountRequest.send_payer_email_to_gateway,
+          invalidCreateGatewayAccountRequest.send_payer_ip_address_to_gateway
+        )
+        .should.be.rejected.then(function (response) {
+          expect(response.errorCode).to.equal(422)
+          expect(response.message).to.equal(errorResponse.message[0])
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-get-card-types.pact.test.js
+++ b/test/pact/connector-client/connector-get-card-types.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ describe('connector client', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -38,15 +38,17 @@ describe('connector client', function () {
     const validCardTypesResponse = cardFixtures.validCardTypesResponse()
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${CARD_TYPES_RESOURCE}`)
-          .withUponReceiving('a valid card types request')
-          .withState('Card types exist in the database')
-          .withMethod('GET')
-          .withStatusCode(200)
-          .withResponseBody(pactify(validCardTypesResponse))
-          .build()
-      ).then(() => done())
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${CARD_TYPES_RESOURCE}`)
+            .withUponReceiving('a valid card types request')
+            .withState('Card types exist in the database')
+            .withMethod('GET')
+            .withStatusCode(200)
+            .withResponseBody(pactify(validCardTypesResponse))
+            .build()
+        )
+        .then(() => done())
         .catch(done)
     })
 
@@ -54,7 +56,7 @@ describe('connector client', function () {
 
     it('should get card types successfully', function (done) {
       const getCardTypes = validCardTypesResponse
-      connectorClient.getAllCardTypes().then(response => {
+      connectorClient.getAllCardTypes().then((response) => {
         expect(response).to.deep.equal(getCardTypes)
         done()
       })

--- a/test/pact/connector-client/connector-get-charge-with-authorisation-summary.test.js
+++ b/test/pact/connector-client/connector-get-charge-with-authorisation-summary.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -28,7 +28,7 @@ describe('connector client - get single charge', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -42,34 +42,36 @@ describe('connector client - get single charge', () => {
       chargeId: existingChargeExternalId,
       state: {
         status: 'success',
-        finished: true
+        finished: true,
       },
       exemption: {
-        requested: false
-      }
+        requested: false,
+      },
     }
     const response = chargeFixture.validGetChargeResponseWithAuthSummary(opts)
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/charges/${existingChargeExternalId}`)
+        new PactInteractionBuilder(
+          `${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/charges/${existingChargeExternalId}`
+        )
           .withUponReceiving('a valid get charge which has authorisation summary request')
           .withState('a charge exists')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
     it('should get a charge which has authorisation summary successfully', function () {
-      return connectorClient.getCharge(existingGatewayAccountId, existingChargeExternalId)
-        .then(charge => {
-          expect(charge.charge_id).to.equal(existingChargeExternalId)
-          expect(charge.authorisation_summary.three_d_secure.required).to.equal(true)
-          expect(charge.authorisation_summary.three_d_secure.version).to.equal('2.1.0')
-        })
+      return connectorClient.getCharge(existingGatewayAccountId, existingChargeExternalId).then((charge) => {
+        expect(charge.charge_id).to.equal(existingChargeExternalId)
+        expect(charge.authorisation_summary.three_d_secure.required).to.equal(true)
+        expect(charge.authorisation_summary.three_d_secure.version).to.equal('2.1.0')
+      })
     })
   })
 })

--- a/test/pact/connector-client/connector-get-charge-with-corporate-exemption-honoured.pact.test.js
+++ b/test/pact/connector-client/connector-get-charge-with-corporate-exemption-honoured.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -28,7 +28,7 @@ describe('connector client - get single charge', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -42,33 +42,35 @@ describe('connector client - get single charge', () => {
       chargeId: existingChargeExternalId,
       state: {
         status: 'success',
-        finished: true
+        finished: true,
       },
-      authorisation_summary: { three_d_secure: { required: false } }
+      authorisation_summary: { three_d_secure: { required: false } },
     }
     const response = chargeFixture.validGetChargeResponseWithExemption(opts)
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/charges/${existingChargeExternalId}`)
+        new PactInteractionBuilder(
+          `${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/charges/${existingChargeExternalId}`
+        )
           .withUponReceiving('a valid get charge which has an honoured corporate exemption request')
           .withState('a charge with honoured corporate exemption exists')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
     it('should get a charge which has an honoured corporate exemption successfully', function () {
-      return connectorClient.getCharge(existingGatewayAccountId, existingChargeExternalId)
-        .then(charge => {
-          expect(charge.charge_id).to.equal(existingChargeExternalId)
-          expect(charge.exemption.requested).to.equal(true)
-          expect(charge.exemption.type).to.equal('corporate')
-          expect(charge.exemption.outcome.result).to.equal('honoured')
-        })
+      return connectorClient.getCharge(existingGatewayAccountId, existingChargeExternalId).then((charge) => {
+        expect(charge.charge_id).to.equal(existingChargeExternalId)
+        expect(charge.exemption.requested).to.equal(true)
+        expect(charge.exemption.type).to.equal('corporate')
+        expect(charge.exemption.outcome.result).to.equal('honoured')
+      })
     })
   })
 })

--- a/test/pact/connector-client/connector-get-charge.pact.test.js
+++ b/test/pact/connector-client/connector-get-charge.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -23,7 +23,7 @@ const provider = new Pact({
   log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
   dir: path.resolve(process.cwd(), 'pacts'),
   spec: 2,
-  pactfileWriteMode: 'merge'
+  pactfileWriteMode: 'merge',
 })
 
 describe('connector client - get single charge by service external id and account type', () => {
@@ -42,27 +42,31 @@ describe('connector client - get single charge by service external id and accoun
       chargeId: existingChargeExternalId,
       state: {
         status: 'success',
-        finished: true
-      }
+        finished: true,
+      },
     }
     const response = chargeFixture.validGetChargeResponse(opts)
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/service/${serviceExternalId}/account/test/charges/${existingChargeExternalId}`)
+        new PactInteractionBuilder(
+          `/v1/api/service/${serviceExternalId}/account/test/charges/${existingChargeExternalId}`
+        )
           .withUponReceiving('a valid get charge request')
           .withState(defaultState)
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
     it('should get a charge successfully', function () {
-      return connectorClient.getChargeByServiceExternalIdAndAccountType(serviceExternalId, 'test', existingChargeExternalId)
-        .then(charge => {
+      return connectorClient
+        .getChargeByServiceExternalIdAndAccountType(serviceExternalId, 'test', existingChargeExternalId)
+        .then((charge) => {
           expect(charge.charge_id).to.equal(existingChargeExternalId)
           expect(charge.state.status).to.equal('success')
           expect(charge.state.finished).to.equal(true)
@@ -87,8 +91,8 @@ describe('connector client - get single charge by gateway account id', () => {
       chargeId: existingChargeExternalId,
       state: {
         status: 'success',
-        finished: true
-      }
+        finished: true,
+      },
     }
     const response = chargeFixture.validGetChargeResponse(opts)
 
@@ -100,18 +104,18 @@ describe('connector client - get single charge by gateway account id', () => {
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
     it('should get a charge successfully', function () {
-      return connectorClient.getCharge(existingGatewayAccountId, existingChargeExternalId)
-        .then(charge => {
-          expect(charge.charge_id).to.equal(existingChargeExternalId)
-          expect(charge.state.status).to.equal('success')
-          expect(charge.state.finished).to.equal(true)
-        })
+      return connectorClient.getCharge(existingGatewayAccountId, existingChargeExternalId).then((charge) => {
+        expect(charge.charge_id).to.equal(existingChargeExternalId)
+        expect(charge.state.status).to.equal('success')
+        expect(charge.state.finished).to.equal(true)
+      })
     })
   })
 })

--- a/test/pact/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
+++ b/test/pact/connector-client/connector-get-gateway-account-by-external-id.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 
 const path = require('path')
@@ -22,7 +22,7 @@ describe('connector client - get gateway account by external id', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,26 +37,28 @@ describe('connector client - get gateway account by external id', function () {
       payment_provider: 'worldpay',
       description: 'A description',
       analytics_id: 'an-analytics-id',
-      gateway_account_credentials: [{
-        credentials: {
-          one_off_customer_initiated: {
-            merchant_code: 'a-merchant-code',
-            username: 'a-username'
+      gateway_account_credentials: [
+        {
+          credentials: {
+            one_off_customer_initiated: {
+              merchant_code: 'a-merchant-code',
+              username: 'a-username',
+            },
+            recurring_customer_initiated: {
+              username: 'a-username',
+              merchant_code: 'a-merchant-code',
+            },
+            recurring_merchant_initiated: {
+              username: 'a-username',
+              merchant_code: 'a-merchant-code',
+            },
           },
-          recurring_customer_initiated: {
-            username: 'a-username',
-            merchant_code: 'a-merchant-code'
-          },
-          recurring_merchant_initiated: {
-            username: 'a-username',
-            merchant_code: 'a-merchant-code'
-          }
-        }
-      }],
+        },
+      ],
       worldpay_3ds_flex: {
         organisational_unit_id: 'an-org-id',
-        issuer: 'an-issues'
-      }
+        issuer: 'an-issues',
+      },
     })
 
     before(() => {
@@ -75,7 +77,7 @@ describe('connector client - get gateway account by external id', function () {
 
     it('should get gateway account successfully', async () => {
       const params = {
-        gatewayAccountExternalId
+        gatewayAccountExternalId,
       }
       const response = await connectorClient.getAccountByExternalId(params)
       expect(response).to.deep.equal(validGetGatewayAccountResponse)
@@ -87,7 +89,7 @@ describe('connector client - get gateway account by external id', function () {
       external_id: gatewayAccountExternalId,
       payment_provider: 'worldpay',
       description: 'A description',
-      analytics_id: 'an-analytics-id'
+      analytics_id: 'an-analytics-id',
     })
 
     before(() => {
@@ -106,7 +108,7 @@ describe('connector client - get gateway account by external id', function () {
 
     it('should get gateway account successfully', async () => {
       const params = {
-        gatewayAccountExternalId
+        gatewayAccountExternalId,
       }
       const response = await connectorClient.getAccountByExternalId(params)
       expect(response).to.deep.equal(validGetGatewayAccountResponse)

--- a/test/pact/connector-client/connector-get-gateway-account.pact.test.js
+++ b/test/pact/connector-client/connector-get-gateway-account.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('connector client - get gateway account', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -38,19 +38,20 @@ describe('connector client - get gateway account', function () {
 
   describe('get single gateway account - success', () => {
     const validGetGatewayAccountResponse = gatewayAccountFixtures.validGatewayAccountResponse({
-      gateway_account_id: existingGatewayAccountId
+      gateway_account_id: existingGatewayAccountId,
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
-          .withUponReceiving('a valid get gateway account request')
-          .withState(`User ${existingGatewayAccountId} exists in the database`)
-          .withMethod('GET')
-          .withResponseBody(pactify(validGetGatewayAccountResponse))
-          .withStatusCode(200)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+            .withUponReceiving('a valid get gateway account request')
+            .withState(`User ${existingGatewayAccountId} exists in the database`)
+            .withMethod('GET')
+            .withResponseBody(pactify(validGetGatewayAccountResponse))
+            .withStatusCode(200)
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -59,12 +60,14 @@ describe('connector client - get gateway account', function () {
 
     it('should get gateway account successfully', function (done) {
       const params = {
-        gatewayAccountId: existingGatewayAccountId
+        gatewayAccountId: existingGatewayAccountId,
       }
-      connectorClient.getAccount(params)
+      connectorClient
+        .getAccount(params)
         .should.be.fulfilled.then((response) => {
           expect(response).to.deep.equal(validGetGatewayAccountResponse)
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
+++ b/test/pact/connector-client/connector-get-multiple-gateway-accounts.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ describe('connector client - get multiple gateway accounts', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -36,23 +36,21 @@ describe('connector client - get multiple gateway accounts', function () {
 
   describe('get multiple gateway accounts - success', () => {
     const validGetGatewayAccountsResponse = gatewayAccountFixtures.validGatewayAccountsResponse({
-      accounts: [
-        { gateway_account_id: 111 },
-        { gateway_account_id: 222 }
-      ]
+      accounts: [{ gateway_account_id: 111 }, { gateway_account_id: 222 }],
     })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(ACCOUNTS_RESOURCE)
-          .withUponReceiving('a valid get gateway accounts request')
-          .withState('gateway accounts with ids 111, 222 exist in the database')
-          .withMethod('GET')
-          .withQuery('accountIds', '111,222')
-          .withResponseBody(pactify(validGetGatewayAccountsResponse))
-          .withStatusCode(200)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(ACCOUNTS_RESOURCE)
+            .withUponReceiving('a valid get gateway accounts request')
+            .withState('gateway accounts with ids 111, 222 exist in the database')
+            .withMethod('GET')
+            .withQuery('accountIds', '111,222')
+            .withResponseBody(pactify(validGetGatewayAccountsResponse))
+            .withStatusCode(200)
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -60,10 +58,12 @@ describe('connector client - get multiple gateway accounts', function () {
     afterEach(() => provider.verify())
 
     it('should get multiple gateway accounts successfully', function (done) {
-      connectorClient.getAccounts({ gatewayAccountIds: [111, 222] })
+      connectorClient
+        .getAccounts({ gatewayAccountIds: [111, 222] })
         .should.be.fulfilled.then((response) => {
           expect(response).to.deep.equal(validGetGatewayAccountsResponse)
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-get-stripe-account-setup.pact.test.js
+++ b/test/pact/connector-client/connector-get-stripe-account-setup.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -28,7 +28,7 @@ describe('connector client - get stripe account setup', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -42,35 +42,37 @@ describe('connector client - get stripe account setup', () => {
       bank_account: true,
       responsible_person: true,
       vat_number: false,
-      company_number: false
+      company_number: false,
     }
     const response = stripeAccountSetupFixtures.buildGetStripeAccountSetupResponse(stripeSetupOpts)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
-          .withUponReceiving('a valid get stripe account bank account flag request')
-          .withState(defaultState)
-          .withMethod('GET')
-          .withStatusCode(200)
-          .withResponseBody(pactify(response))
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+            .withUponReceiving('a valid get stripe account bank account flag request')
+            .withState(defaultState)
+            .withMethod('GET')
+            .withStatusCode(200)
+            .withResponseBody(pactify(response))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should update successfully', done => {
-      connectorClient.getStripeAccountSetup(existingGatewayAccountId)
-        .should.be.fulfilled
-        .then(stripeAccountSetup => {
+    it('should update successfully', (done) => {
+      connectorClient
+        .getStripeAccountSetup(existingGatewayAccountId)
+        .should.be.fulfilled.then((stripeAccountSetup) => {
           expect(stripeAccountSetup.bankAccount).to.equal(stripeSetupOpts.bank_account)
           expect(stripeAccountSetup.vatNumber).to.equal(stripeSetupOpts.vat_number)
           expect(stripeAccountSetup.companyNumber).to.equal(stripeSetupOpts.company_number)
           expect(stripeAccountSetup.responsiblePerson).to.equal(stripeSetupOpts.responsible_person)
-        }).should.notify(done)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-get-stripe-account.pact.test.js
+++ b/test/pact/connector-client/connector-get-stripe-account.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -28,7 +28,7 @@ describe('connector client - get stripe account', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -39,30 +39,34 @@ describe('connector client - get stripe account', () => {
 
   describe('get stripe account setup success', () => {
     const stripeAccountOpts = {
-      stripe_account_id: 'acct_123example123'
+      stripe_account_id: 'acct_123example123',
     }
     const response = stripeAccountFixtures.buildGetStripeAccountResponse(stripeAccountOpts)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-account`)
-          .withUponReceiving('a valid get stripe account request')
-          .withState(defaultState)
-          .withMethod('GET')
-          .withStatusCode(200)
-          .withResponseBody(pactify(response))
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-account`)
+            .withUponReceiving('a valid get stripe account request')
+            .withState(defaultState)
+            .withMethod('GET')
+            .withStatusCode(200)
+            .withResponseBody(pactify(response))
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should get successfully', done => {
-      connectorClient.getStripeAccount(existingGatewayAccountId, 'correlation-id').should.be.fulfilled.then(stripeAccount => {
-        expect(stripeAccount.stripeAccountId).to.equal(stripeAccountOpts.stripe_account_id)
-      }).should.notify(done)
+    it('should get successfully', (done) => {
+      connectorClient
+        .getStripeAccount(existingGatewayAccountId, 'correlation-id')
+        .should.be.fulfilled.then((stripeAccount) => {
+          expect(stripeAccount.stripeAccountId).to.equal(stripeAccountOpts.stripe_account_id)
+        })
+        .should.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-patch-apple-pay-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-apple-pay-toggle.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('connector client - patch apple pay toggle (enabled) request', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,8 +37,7 @@ describe('connector client - patch apple pay toggle (enabled) request', () => {
   after(() => provider.finalize())
 
   describe('apple pay toggle - supported payment provider request', () => {
-    const applePayToggleSupportedPaymentProviderState =
-      `a gateway account supporting digital wallet with external id ${existingGatewayAccountId} exists in the database`
+    const applePayToggleSupportedPaymentProviderState = `a gateway account supporting digital wallet with external id ${existingGatewayAccountId} exists in the database`
 
     before(() => {
       return provider.addInteraction(
@@ -49,15 +48,14 @@ describe('connector client - patch apple pay toggle (enabled) request', () => {
           .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
-    it('should toggle successfully', done => {
-      connectorClient.toggleApplePay(existingGatewayAccountId, true, null)
-        .should.be.fulfilled
-        .notify(done)
+    it('should toggle successfully', (done) => {
+      connectorClient.toggleApplePay(existingGatewayAccountId, true, null).should.be.fulfilled.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-patch-email-collection-mode.pact.test.js
+++ b/test/pact/connector-client/connector-patch-email-collection-mode.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('connector client - patch email collection mode', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -41,16 +41,17 @@ describe('connector client - patch email collection mode', function () {
       gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('MANDATORY')
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
-          .withUponReceiving('a valid patch email collection mode (mandatory) request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+            .withUponReceiving('a valid patch email collection mode (mandatory) request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -60,7 +61,7 @@ describe('connector client - patch email collection mode', function () {
     it('should set email collection mode to mandatory', function () {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailCollectionModeRequest
+        payload: validGatewayAccountEmailCollectionModeRequest,
       }
       return expect(connectorClient.updateEmailCollectionMode(params)).to.be.fulfilled
     })
@@ -71,16 +72,17 @@ describe('connector client - patch email collection mode', function () {
       gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('OPTIONAL')
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
-          .withUponReceiving('a valid patch email collection mode (optional) request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+            .withUponReceiving('a valid patch email collection mode (optional) request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -90,7 +92,7 @@ describe('connector client - patch email collection mode', function () {
     it('should set email collection mode to optional', function () {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailCollectionModeRequest
+        payload: validGatewayAccountEmailCollectionModeRequest,
       }
       return expect(connectorClient.updateEmailCollectionMode(params)).to.be.fulfilled
     })
@@ -101,16 +103,17 @@ describe('connector client - patch email collection mode', function () {
       gatewayAccountFixtures.validGatewayAccountEmailCollectionModeRequest('OFF')
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
-          .withUponReceiving('a valid patch email collection mode (off) request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}`)
+            .withUponReceiving('a valid patch email collection mode (off) request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(validGatewayAccountEmailCollectionModeRequest)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -120,7 +123,7 @@ describe('connector client - patch email collection mode', function () {
     it('should set email collection mode to mandatory', function () {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailCollectionModeRequest
+        payload: validGatewayAccountEmailCollectionModeRequest,
       }
       return expect(connectorClient.updateEmailCollectionMode(params)).to.be.fulfilled
     })

--- a/test/pact/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-email-confirmation-toggle.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('connector client - patch email confirmation toggle', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,19 +37,21 @@ describe('connector client - patch email confirmation toggle', function () {
   after(() => provider.finalize())
 
   describe('patch email confirmation toggle - enabled', () => {
-    const validGatewayAccountEmailConfirmationToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(true)
+    const validGatewayAccountEmailConfirmationToggleRequest =
+      gatewayAccountFixtures.validGatewayAccountEmailConfirmationToggleRequest(true)
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/email-notification`)
-          .withUponReceiving('a valid patch email confirmation toggle (enabled) request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailConfirmationToggleRequest)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/email-notification`)
+            .withUponReceiving('a valid patch email confirmation toggle (enabled) request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(validGatewayAccountEmailConfirmationToggleRequest)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -59,7 +61,7 @@ describe('connector client - patch email confirmation toggle', function () {
     it('should toggle successfully', function () {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailConfirmationToggleRequest
+        payload: validGatewayAccountEmailConfirmationToggleRequest,
       }
 
       return expect(connectorClient.updateConfirmationEmailEnabled(params)).to.be.fulfilled

--- a/test/pact/connector-client/connector-patch-email-refund-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-email-refund-toggle.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('connector client - patch email refund toggle', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,19 +37,21 @@ describe('connector client - patch email refund toggle', function () {
   after(() => provider.finalize())
 
   describe('patch email refund toggle - enabled', () => {
-    const validGatewayAccountEmailRefundToggleRequest = gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(true)
+    const validGatewayAccountEmailRefundToggleRequest =
+      gatewayAccountFixtures.validGatewayAccountEmailRefundToggleRequest(true)
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/email-notification`)
-          .withUponReceiving('a valid patch email refund toggle (enabled) request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(validGatewayAccountEmailRefundToggleRequest)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/email-notification`)
+            .withUponReceiving('a valid patch email refund toggle (enabled) request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(validGatewayAccountEmailRefundToggleRequest)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
@@ -59,7 +61,7 @@ describe('connector client - patch email refund toggle', function () {
     it('should toggle successfully', function () {
       const params = {
         gatewayAccountId: existingGatewayAccountId,
-        payload: validGatewayAccountEmailRefundToggleRequest
+        payload: validGatewayAccountEmailRefundToggleRequest,
       }
 
       return expect(connectorClient.updateRefundEmailEnabled(params)).to.be.fulfilled

--- a/test/pact/connector-client/connector-patch-gateway-account-credential-state.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credential-state.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const path = require('path')
 
@@ -21,7 +21,7 @@ describe('connector client - patch gateway account credentials.state', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,20 +37,24 @@ describe('connector client - patch gateway account credentials.state', () => {
       gatewayAccountId: '444',
       gatewayAccountCredentialsId: '555',
       state,
-      userExternalId
+      userExternalId,
     }
     const request = gatewayAccountFixtures.validPatchAccountGatewayAccountCredentialsStateRequest(requestPayload)
     const response = gatewayAccountFixtures.validPatchGatewayCredentialsResponse({
       gatewayAccountId: existingGatewayAccountId,
       gatewayAccountCredentialId: existingGatewayAccountCredentialsId,
       state,
-      lastUpdatedByUserExternalId: userExternalId
+      lastUpdatedByUserExternalId: userExternalId,
     })
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
-          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId} and valid credentials`)
+        new PactInteractionBuilder(
+          `/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`
+        )
+          .withState(
+            `a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId} and valid credentials`
+          )
           .withUponReceiving('a request to update state for a gateway account credentials')
           .withMethod('PATCH')
           .withRequestHeaders({ 'Content-Type': 'application/json' })
@@ -58,7 +62,8 @@ describe('connector client - patch gateway account credentials.state', () => {
           .withStatusCode(200)
           .withResponseHeaders({ 'Content-Type': 'application/json' })
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())

--- a/test/pact/connector-client/connector-patch-gateway-account-credentials-customer-initiated.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credentials-customer-initiated.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const path = require('path')
 
@@ -22,7 +22,7 @@ describe('connector client - patch gateway account credentials for recurring cus
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -35,29 +35,33 @@ describe('connector client - patch gateway account credentials for recurring cus
     const credentialsInRequest = {
       username: 'a-username',
       password: 'a-password', // pragma: allowlist secret
-      merchant_code: 'a-merchant-code'
+      merchant_code: 'a-merchant-code',
     }
     const credentialsInResponse = {
       recurring_customer_initiated: {
         username: 'a-username',
-        merchant_code: 'a-merchant-code'
-      }
+        merchant_code: 'a-merchant-code',
+      },
     }
     const userExternalId = 'a-user-external-id'
     const request = gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest({
       credentials: credentialsInRequest,
       path: worldpayMerchantDetailOperations.RECURRING_CUSTOMER_INITIATED.patch,
-      userExternalId
+      userExternalId,
     })
     const response = gatewayAccountFixtures.validGatewayAccountCredentialsResponse({
       credentials: credentialsInResponse,
-      lastUpdatedByUserExternalId: userExternalId
+      lastUpdatedByUserExternalId: userExternalId,
     })
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
-          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`)
+        new PactInteractionBuilder(
+          `/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`
+        )
+          .withState(
+            `a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`
+          )
           .withUponReceiving('a request to update credentials map for recurring customer initiated credentials')
           .withMethod('PATCH')
           .withRequestHeaders({ 'Content-Type': 'application/json' })
@@ -65,7 +69,8 @@ describe('connector client - patch gateway account credentials for recurring cus
           .withStatusCode(200)
           .withResponseHeaders({ 'Content-Type': 'application/json' })
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
@@ -76,7 +81,7 @@ describe('connector client - patch gateway account credentials for recurring cus
         gatewayAccountCredentialsId: existingGatewayAccountCredentialsId,
         credentials: credentialsInRequest,
         path: worldpayMerchantDetailOperations.RECURRING_CUSTOMER_INITIATED.patch,
-        userExternalId
+        userExternalId,
       })
       expect(connectorResponse.credentials).to.deep.equal(credentialsInResponse)
     })

--- a/test/pact/connector-client/connector-patch-gateway-account-credentials-merchant-initiated.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credentials-merchant-initiated.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const path = require('path')
 
@@ -22,7 +22,7 @@ describe('connector client - patch gateway account credentials for recurring mer
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -35,29 +35,33 @@ describe('connector client - patch gateway account credentials for recurring mer
     const credentialsInRequest = {
       username: 'a-username',
       password: 'a-password', // pragma: allowlist secret
-      merchant_code: 'a-merchant-code'
+      merchant_code: 'a-merchant-code',
     }
     const credentialsInResponse = {
       recurring_merchant_initiated: {
         username: 'a-username',
-        merchant_code: 'a-merchant-code'
-      }
+        merchant_code: 'a-merchant-code',
+      },
     }
     const userExternalId = 'a-user-external-id'
     const request = gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest({
       credentials: credentialsInRequest,
       path: worldpayMerchantDetailOperations.RECURRING_MERCHANT_INITIATED.patch,
-      userExternalId
+      userExternalId,
     })
     const response = gatewayAccountFixtures.validGatewayAccountCredentialsResponse({
       credentials: credentialsInResponse,
-      lastUpdatedByUserExternalId: userExternalId
+      lastUpdatedByUserExternalId: userExternalId,
     })
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
-          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`)
+        new PactInteractionBuilder(
+          `/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`
+        )
+          .withState(
+            `a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`
+          )
           .withUponReceiving('a request to update credentials map for recurring merchant initiated credentials')
           .withMethod('PATCH')
           .withRequestHeaders({ 'Content-Type': 'application/json' })
@@ -65,7 +69,8 @@ describe('connector client - patch gateway account credentials for recurring mer
           .withStatusCode(200)
           .withResponseHeaders({ 'Content-Type': 'application/json' })
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
@@ -76,7 +81,7 @@ describe('connector client - patch gateway account credentials for recurring mer
         gatewayAccountCredentialsId: existingGatewayAccountCredentialsId,
         credentials: credentialsInRequest,
         path: worldpayMerchantDetailOperations.RECURRING_MERCHANT_INITIATED.patch,
-        userExternalId
+        userExternalId,
       })
       expect(connectorResponse.credentials).to.deep.equal(credentialsInResponse)
     })

--- a/test/pact/connector-client/connector-patch-gateway-account-credentials-one-off.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-credentials-one-off.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const path = require('path')
 
@@ -22,7 +22,7 @@ describe('connector client - patch gateway account credentials for one off trans
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -35,29 +35,33 @@ describe('connector client - patch gateway account credentials for one off trans
     const credentialsInRequest = {
       username: 'a-username',
       password: 'a-password', // pragma: allowlist secret
-      merchant_code: 'a-merchant-code'
+      merchant_code: 'a-merchant-code',
     }
     const credentialsInResponse = {
       one_off_customer_initiated: {
         username: 'a-username',
-        merchant_code: 'a-merchant-code'
-      }
+        merchant_code: 'a-merchant-code',
+      },
     }
     const userExternalId = 'a-user-external-id'
     const request = gatewayAccountFixtures.validUpdateGatewayAccountCredentialsRequest({
       credentials: credentialsInRequest,
       path: worldpayMerchantDetailOperations.ONE_OFF_CUSTOMER_INITIATED.patch,
-      userExternalId
+      userExternalId,
     })
     const response = gatewayAccountFixtures.validGatewayAccountCredentialsResponse({
       credentials: credentialsInResponse,
-      lastUpdatedByUserExternalId: userExternalId
+      lastUpdatedByUserExternalId: userExternalId,
     })
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
-          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`)
+        new PactInteractionBuilder(
+          `/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`
+        )
+          .withState(
+            `a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId}`
+          )
           .withUponReceiving('a request to update credentials map for one off credentials')
           .withMethod('PATCH')
           .withRequestHeaders({ 'Content-Type': 'application/json' })
@@ -65,7 +69,8 @@ describe('connector client - patch gateway account credentials for one off trans
           .withStatusCode(200)
           .withResponseHeaders({ 'Content-Type': 'application/json' })
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
@@ -76,7 +81,7 @@ describe('connector client - patch gateway account credentials for one off trans
         gatewayAccountCredentialsId: existingGatewayAccountCredentialsId,
         credentials: credentialsInRequest,
         path: worldpayMerchantDetailOperations.ONE_OFF_CUSTOMER_INITIATED.patch,
-        userExternalId
+        userExternalId,
       })
       expect(connectorResponse.credentials).to.deep.equal(credentialsInResponse)
     })

--- a/test/pact/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js
+++ b/test/pact/connector-client/connector-patch-gateway-account-merchant-id.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const path = require('path')
 
@@ -21,7 +21,7 @@ describe('connector client - patch gateway account credentials.gateway_merchant_
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -34,21 +34,25 @@ describe('connector client - patch gateway account credentials.gateway_merchant_
     const userExternalId = 'a-user-external-id'
     const googlePayGatewayMerchantId = 'abcdef123abcdef'
     const credentialsInResponse = {
-      gateway_merchant_id: googlePayGatewayMerchantId
+      gateway_merchant_id: googlePayGatewayMerchantId,
     }
     const request = gatewayAccountFixtures.validPatchWorldpayGooglePayMerchantIdRequest({
       googlePayMerchantId: googlePayGatewayMerchantId,
-      userExternalId
+      userExternalId,
     })
     const response = gatewayAccountFixtures.validPatchGatewayCredentialsResponse({
       credentials: credentialsInResponse,
-      lastUpdatedByUserExternalId: userExternalId
+      lastUpdatedByUserExternalId: userExternalId,
     })
 
     before(() => {
       return provider.addInteraction(
-        new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`)
-          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId} and valid credentials`)
+        new PactInteractionBuilder(
+          `/v1/api/accounts/${existingGatewayAccountId}/credentials/${existingGatewayAccountCredentialsId}`
+        )
+          .withState(
+            `a Worldpay gateway account with id ${existingGatewayAccountId} with gateway account credentials with id ${existingGatewayAccountCredentialsId} and valid credentials`
+          )
           .withUponReceiving('a request to update google pay gateway merchant id for a gateway account credentials')
           .withMethod('PATCH')
           .withRequestHeaders({ 'Content-Type': 'application/json' })
@@ -56,13 +60,19 @@ describe('connector client - patch gateway account credentials.gateway_merchant_
           .withStatusCode(200)
           .withResponseHeaders({ 'Content-Type': 'application/json' })
           .withResponseBody(pactify(response))
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
     it('should patch gateway merchant id credentials', async () => {
-      const connectorResponse = await connectorClient.patchGooglePayGatewayMerchantId(existingGatewayAccountId, existingGatewayAccountCredentialsId, googlePayGatewayMerchantId, userExternalId)
+      const connectorResponse = await connectorClient.patchGooglePayGatewayMerchantId(
+        existingGatewayAccountId,
+        existingGatewayAccountCredentialsId,
+        googlePayGatewayMerchantId,
+        userExternalId
+      )
       expect(connectorResponse.credentials).to.deep.equal(credentialsInResponse)
     })
   })

--- a/test/pact/connector-client/connector-patch-google-pay-toggle.pact.test.js
+++ b/test/pact/connector-client/connector-patch-google-pay-toggle.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('connector client - patch google pay toggle (enabled) request', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,8 +37,7 @@ describe('connector client - patch google pay toggle (enabled) request', () => {
   after(() => provider.finalize())
 
   describe('google pay toggle - supported payment provider request', () => {
-    const googlePayToggleSupportedPaymentProviderState =
-      `a gateway account supporting digital wallet with external id ${existingGatewayAccountId} exists in the database`
+    const googlePayToggleSupportedPaymentProviderState = `a gateway account supporting digital wallet with external id ${existingGatewayAccountId} exists in the database`
 
     before(() => {
       return provider.addInteraction(
@@ -49,15 +48,14 @@ describe('connector client - patch google pay toggle (enabled) request', () => {
           .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
-    it('should toggle successfully', done => {
-      connectorClient.toggleGooglePay(existingGatewayAccountId, true, null)
-        .should.be.fulfilled
-        .notify(done)
+    it('should toggle successfully', (done) => {
+      connectorClient.toggleGooglePay(existingGatewayAccountId, true, null).should.be.fulfilled.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-patch-integration-version-3ds.pact.test.js
+++ b/test/pact/connector-client/connector-patch-integration-version-3ds.pact.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -27,7 +27,7 @@ describe('Update 3DS integration version', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -49,15 +49,14 @@ describe('Update 3DS integration version', () => {
           .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
-    it('should set version to 1 successfully', done => {
-      connectorClient.updateIntegrationVersion3ds(existingGatewayAccountId, 1, null)
-        .should.be.fulfilled
-        .notify(done)
+    it('should set version to 1 successfully', (done) => {
+      connectorClient.updateIntegrationVersion3ds(existingGatewayAccountId, 1, null).should.be.fulfilled.notify(done)
     })
   })
 
@@ -74,15 +73,14 @@ describe('Update 3DS integration version', () => {
           .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
-    it('should set version to 2 successfully', done => {
-      connectorClient.updateIntegrationVersion3ds(existingGatewayAccountId, 2, null)
-        .should.be.fulfilled
-        .notify(done)
+    it('should set version to 2 successfully', (done) => {
+      connectorClient.updateIntegrationVersion3ds(existingGatewayAccountId, 2, null).should.be.fulfilled.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-patch-moto-mask-card-number.pact.test.js
+++ b/test/pact/connector-client/connector-patch-moto-mask-card-number.pact.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -28,7 +28,7 @@ describe('connector client - patch MOTO mask card number toggle (enabled) reques
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -38,8 +38,7 @@ describe('connector client - patch MOTO mask card number toggle (enabled) reques
   after(() => provider.finalize())
 
   describe('MOTO mask card number input toggle - supported payment provider request', () => {
-    const motoMaskCardNumberInputProviderState =
-      `a gateway account with MOTO enabled and an external id ${existingGatewayAccountId} exists in the database`
+    const motoMaskCardNumberInputProviderState = `a gateway account with MOTO enabled and an external id ${existingGatewayAccountId} exists in the database`
 
     before(() => {
       return provider.addInteraction(
@@ -50,15 +49,16 @@ describe('connector client - patch MOTO mask card number toggle (enabled) reques
           .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
-    it('should toggle successfully', done => {
-      connectorClient.toggleMotoMaskCardNumberInput(existingGatewayAccountId, true, null)
-        .should.be.fulfilled
-        .notify(done)
+    it('should toggle successfully', (done) => {
+      connectorClient
+        .toggleMotoMaskCardNumberInput(existingGatewayAccountId, true, null)
+        .should.be.fulfilled.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-patch-moto-mask-security-code.pact.test.js
+++ b/test/pact/connector-client/connector-patch-moto-mask-security-code.pact.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -29,7 +29,7 @@ describe('connector client - patch MOTO mask security code toggle (enabled) requ
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -39,8 +39,7 @@ describe('connector client - patch MOTO mask security code toggle (enabled) requ
   after(() => provider.finalize())
 
   describe('MOTO mask security code input toggle - supported payment provider request', () => {
-    const motoMaskSecurityCodeInputProviderState =
-      `a gateway account with MOTO enabled and an external id ${existingGatewayAccountId} exists in the database`
+    const motoMaskSecurityCodeInputProviderState = `a gateway account with MOTO enabled and an external id ${existingGatewayAccountId} exists in the database`
 
     before(() => {
       return provider.addInteraction(
@@ -51,15 +50,16 @@ describe('connector client - patch MOTO mask security code toggle (enabled) requ
           .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
-    it('should toggle successfully', done => {
-      connectorClient.toggleMotoMaskSecurityCodeInput(existingGatewayAccountId, true, null)
-        .should.be.fulfilled
-        .notify(done)
+    it('should toggle successfully', (done) => {
+      connectorClient
+        .toggleMotoMaskSecurityCodeInput(existingGatewayAccountId, true, null)
+        .should.be.fulfilled.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-post-cancel-agreement.pact.test.js
+++ b/test/pact/connector-client/connector-post-cancel-agreement.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -25,7 +25,7 @@ describe('connector client', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {

--- a/test/pact/connector-client/connector-post-create-charge.pact.test.js
+++ b/test/pact/connector-client/connector-post-create-charge.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -26,7 +26,7 @@ describe('connector client', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -40,7 +40,7 @@ describe('connector client', function () {
       const validPostCreateChargeRequest = chargeFixture.validPostChargeRequestRequest({
         amount: 100,
         return_url: 'https://somewhere.gov.uk/rainbow/1',
-        credential_id: 'creds123'
+        credential_id: 'creds123',
       })
 
       const validResponse = chargeFixture.validPostChargeRequestResponse()
@@ -49,7 +49,9 @@ describe('connector client', function () {
         return provider.addInteraction(
           new PactInteractionBuilder(`${CHARGES_RESOURCE}/${gatewayAccountId}/charges`)
             .withUponReceiving('a valid post create charge request')
-            .withState('a Worldpay gateway account with id 3456, gateway account credentials with external_id creds123 exists')
+            .withState(
+              'a Worldpay gateway account with id 3456, gateway account credentials with external_id creds123 exists'
+            )
             .withMethod('POST')
             .withRequestBody(validPostCreateChargeRequest)
             .withStatusCode(201)
@@ -62,7 +64,10 @@ describe('connector client', function () {
       afterEach(() => provider.verify())
 
       it('should create a charge request successfully', async () => {
-        const connectorResponse = await connectorClient.postChargeRequest(gatewayAccountId, validPostCreateChargeRequest)
+        const connectorResponse = await connectorClient.postChargeRequest(
+          gatewayAccountId,
+          validPostCreateChargeRequest
+        )
         expect(connectorResponse.state.status).to.equal('created')
         expect(connectorResponse.return_url).to.equal('https://somewhere.gov.uk/rainbow/1')
         expect(connectorResponse.links).to.be.a('array')

--- a/test/pact/connector-client/connector-post-refund.pact.test.js
+++ b/test/pact/connector-client/connector-post-refund.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
@@ -29,7 +29,7 @@ describe('connector client', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -42,7 +42,7 @@ describe('connector client', function () {
     describe('success', () => {
       const validPostRefundRequest = transactionDetailsFixtures.validTransactionRefundRequest({
         amount: 100,
-        refund_amount_available: 100
+        refund_amount_available: 100,
       })
 
       before(() => {
@@ -68,7 +68,7 @@ describe('connector client', function () {
     describe('failure', () => {
       const invalidTransactionRefundRequest = transactionDetailsFixtures.validTransactionRefundRequest({
         amount: 101,
-        refund_amount_available: 100
+        refund_amount_available: 100,
       })
       const invalidTransactionRefundResponse = transactionDetailsFixtures.invalidTransactionRefundResponse()
 
@@ -88,8 +88,9 @@ describe('connector client', function () {
       afterEach(() => provider.verify())
 
       it('should fail with a refund amount greater than the refund amount available', () => {
-        return connectorClient.postChargeRefund(gatewayAccountId, chargeId, invalidTransactionRefundRequest, 'correlation-id')
-          .should.be.rejected.then(response => {
+        return connectorClient
+          .postChargeRefund(gatewayAccountId, chargeId, invalidTransactionRefundRequest, 'correlation-id')
+          .should.be.rejected.then((response) => {
             expect(response.errorCode).to.equal(400)
             expect(response.errorIdentifier).to.equal(invalidTransactionRefundResponse.error_identifier)
             expect(response.reason).to.equal(invalidTransactionRefundResponse.reason)

--- a/test/pact/connector-client/connector-post-request-stripe-test-account.pact.test.js
+++ b/test/pact/connector-client/connector-post-request-stripe-test-account.pact.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
 const path = require('path')
 const PactInteractionBuilder = require('../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
 const Connector = require('../../../src/services/clients/connector.client').ConnectorClient
-const { string } = require('@pact-foundation/pact').Matchers
+const { string } = require('@pact-foundation/pact').MatchersV2
 
 // Constants
 let connectorClient
@@ -24,7 +24,7 @@ describe('connector client - request stripe test account', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -38,14 +38,16 @@ describe('connector client - request stripe test account', function () {
       const validResponse = {
         stripe_connect_account_id: 'acct_123',
         gateway_account_id: string('1'),
-        gateway_account_external_id: string('an-external-id')
+        gateway_account_external_id: string('an-external-id'),
       }
 
       before(() => {
         return provider.addInteraction(
           new PactInteractionBuilder(`/v1/api/service/${serviceId}/request-stripe-test-account`)
             .withUponReceiving('a request for a stripe test account')
-            .withState('a sandbox gateway account with service id a-service-id exists and stripe is configured to create a connect account with id acct_123')
+            .withState(
+              'a sandbox gateway account with service id a-service-id exists and stripe is configured to create a connect account with id acct_123'
+            )
             .withMethod('POST')
             .withStatusCode(200)
             .withResponseHeaders({ 'Content-Type': 'application/json' })

--- a/test/pact/connector-client/connector-post-switch-payment-provider.pact.test.js
+++ b/test/pact/connector-client/connector-post-switch-payment-provider.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 
 const PactInteractionBuilder = require('../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
@@ -18,7 +18,7 @@ describe('connector client - post switch payment provider', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -30,29 +30,30 @@ describe('connector client - post switch payment provider', () => {
   describe('when a post to switch payment provider is made', () => {
     const requestPayload = {
       userExternalId: 'a-user-external-id',
-      gatewayAccountCredentialExternalId: 'switchto1234'
+      gatewayAccountCredentialExternalId: 'switchto1234',
     }
     const request = gatewayAccountFixtures.validPostAccountSwitchPSPRequest(requestPayload)
 
     before(() => {
       return provider.addInteraction(
         new PactInteractionBuilder(`/v1/api/accounts/${existingGatewayAccountId}/switch-psp`)
-          .withState(`a Worldpay gateway account with id ${existingGatewayAccountId} with two credentials ready to be switched`)
+          .withState(
+            `a Worldpay gateway account with id ${existingGatewayAccountId} with two credentials ready to be switched`
+          )
           .withUponReceiving('a request to switch payment provider')
           .withMethod('POST')
           .withRequestHeaders({ 'Content-Type': 'application/json' })
           .withRequestBody(request)
           .withStatusCode(200)
           .withResponseHeaders({})
-          .build())
+          .build()
+      )
     })
 
     afterEach(() => provider.verify())
 
-    it('should switch payment provider', done => {
-      connectorClient.postAccountSwitchPSP(existingGatewayAccountId, request)
-        .should.be.fulfilled
-        .notify(done)
+    it('should switch payment provider', (done) => {
+      connectorClient.postAccountSwitchPSP(existingGatewayAccountId, request).should.be.fulfilled.notify(done)
     })
   })
 })

--- a/test/pact/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
+++ b/test/pact/connector-client/connector-post-worldpay-check-3ds-flex-config.pact.test.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const expect = chai.expect
 chai.should()
 chai.use(chaiAsPromised)
@@ -25,7 +25,7 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -37,11 +37,15 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
 
   describe('when a request to check Worldpay 3DS Flex credentials is made', () => {
     describe('and the credentials are valid and pass the existing format validation', () => {
-      const checkValidWorldpay3dsFlexCredentialsRequest = worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest()
-      const checkValidWorldpay3dsFlexCredentialsResponse = worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse()
+      const checkValidWorldpay3dsFlexCredentialsRequest =
+        worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsRequest()
+      const checkValidWorldpay3dsFlexCredentialsResponse =
+        worldpay3dsFlexCredentialsFixtures.checkValidWorldpay3dsFlexCredentialsResponse()
       before(() => {
         return provider.addInteraction(
-          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${EXISTING_GATEWAY_ACCOUNT_ID}/${CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS}`)
+          new PactInteractionBuilder(
+            `${ACCOUNTS_RESOURCE}/${EXISTING_GATEWAY_ACCOUNT_ID}/${CHECK_WORLDPAY_3DS_FLEX_CREDENTIALS}`
+          )
             .withState(`a gateway account ${EXISTING_GATEWAY_ACCOUNT_ID} with Worldpay 3DS Flex credentials exists`)
             .withUponReceiving('a request to check Worldpay 3DS Flex credentials')
             .withMethod('POST')
@@ -55,7 +59,9 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
       })
 
       it('should return valid', async () => {
-        const response = await connectorClient.postCheckWorldpay3dsFlexCredentials(checkValidWorldpay3dsFlexCredentialsRequest)
+        const response = await connectorClient.postCheckWorldpay3dsFlexCredentials(
+          checkValidWorldpay3dsFlexCredentialsRequest
+        )
         expect(response).to.deep.equal(checkValidWorldpay3dsFlexCredentialsResponse)
       })
     })

--- a/test/pact/connector-client/connector-post-worldpay-check-credentials.pact.test.js
+++ b/test/pact/connector-client/connector-post-worldpay-check-credentials.pact.test.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const expect = chai.expect
 chai.should()
 chai.use(chaiAsPromised)
@@ -23,7 +23,7 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -40,7 +40,9 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
       before(() => {
         return provider.addInteraction(
           new PactInteractionBuilder(`/v1/api/accounts/${EXISTING_GATEWAY_ACCOUNT_ID}/worldpay/check-credentials`)
-            .withState(`a Worldpay gateway account with id ${EXISTING_GATEWAY_ACCOUNT_ID} exists and stub for validating credentials is set up`)
+            .withState(
+              `a Worldpay gateway account with id ${EXISTING_GATEWAY_ACCOUNT_ID} exists and stub for validating credentials is set up`
+            )
             .withUponReceiving('a request to check Worldpay credentials')
             .withMethod('POST')
             .withRequestHeaders({ 'Content-Type': 'application/json' })
@@ -53,7 +55,8 @@ describe('connector client - check Worldpay 3DS Flex credentials', () => {
       })
 
       it('should return valid', () => {
-        return connectorClient.postCheckWorldpayCredentials(checkValidWorldpayCredentialsRequest)
+        return connectorClient
+          .postCheckWorldpayCredentials(checkValidWorldpayCredentialsRequest)
           .should.be.fulfilled.then((response) => {
             expect(response).to.deep.equal(checkValidWorldpayCredentialsResponse)
           })

--- a/test/pact/connector-client/connector-set-stripe-account-setup-flag.pact.test.js
+++ b/test/pact/connector-client/connector-set-stripe-account-setup-flag.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -26,7 +26,7 @@ describe('connector client - set stripe account setup flag', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -38,162 +38,164 @@ describe('connector client - set stripe account setup flag', () => {
   describe('set bank account flag', () => {
     const request = stripeAccountSetupFixtures.buildUpdateBankAccountDetailsFlagRequest(true)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
-          .withUponReceiving('a valid patch update stripe account bank account flag request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+            .withUponReceiving('a valid patch update stripe account bank account flag request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should update successfully', done => {
-      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'bank_account')
-        .should.be.fulfilled
-        .notify(done)
+    it('should update successfully', (done) => {
+      connectorClient
+        .setStripeAccountSetupFlag(existingGatewayAccountId, 'bank_account')
+        .should.be.fulfilled.notify(done)
     })
   })
 
   describe('set vat number flag', () => {
     const request = stripeAccountSetupFixtures.buildUpdateVatNumberFlagRequest(true)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
-          .withUponReceiving('a valid patch update stripe account vat number flag request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+            .withUponReceiving('a valid patch update stripe account vat number flag request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should update successfully', done => {
-      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'vat_number')
-        .should.be.fulfilled
-        .notify(done)
+    it('should update successfully', (done) => {
+      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'vat_number').should.be.fulfilled.notify(done)
     })
   })
 
   describe('set company number flag', () => {
     const request = stripeAccountSetupFixtures.buildUpdateCompanyNumberFlagRequest(true)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
-          .withUponReceiving('a valid patch update stripe account company number flag request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+            .withUponReceiving('a valid patch update stripe account company number flag request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should update successfully', done => {
-      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'company_number')
-        .should.be.fulfilled
-        .notify(done)
+    it('should update successfully', (done) => {
+      connectorClient
+        .setStripeAccountSetupFlag(existingGatewayAccountId, 'company_number')
+        .should.be.fulfilled.notify(done)
     })
   })
 
   describe('set responsible person flag', () => {
     const request = stripeAccountSetupFixtures.buildUpdateResponsiblePersonFlagRequest(true)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
-          .withUponReceiving('a valid patch update stripe account responsible person flag request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+            .withUponReceiving('a valid patch update stripe account responsible person flag request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should update successfully', done => {
-      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'responsible_person')
-        .should.be.fulfilled
-        .notify(done)
+    it('should update successfully', (done) => {
+      connectorClient
+        .setStripeAccountSetupFlag(existingGatewayAccountId, 'responsible_person')
+        .should.be.fulfilled.notify(done)
     })
   })
 
   describe('set director flag', () => {
     const request = stripeAccountSetupFixtures.buildUpdateDirectorRequest(true)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
-          .withUponReceiving('a valid patch update stripe account director flag request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+            .withUponReceiving('a valid patch update stripe account director flag request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should update successfully', done => {
-      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'director')
-        .should.be.fulfilled
-        .notify(done)
+    it('should update successfully', (done) => {
+      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'director').should.be.fulfilled.notify(done)
     })
   })
 
   describe('set government_entity_document flag', () => {
     const request = stripeAccountSetupFixtures.buildGovernmentEntityDocumentRequest(true)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
-          .withUponReceiving('a valid patch update stripe account government_entity_document flag request')
-          .withState(defaultState)
-          .withMethod('PATCH')
-          .withRequestBody(request)
-          .withStatusCode(200)
-          .withResponseHeaders({})
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${ACCOUNTS_RESOURCE}/${existingGatewayAccountId}/stripe-setup`)
+            .withUponReceiving('a valid patch update stripe account government_entity_document flag request')
+            .withState(defaultState)
+            .withMethod('PATCH')
+            .withRequestBody(request)
+            .withStatusCode(200)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => done())
         .catch(done)
     })
 
     afterEach(() => provider.verify())
 
-    it('should update successfully', done => {
-      connectorClient.setStripeAccountSetupFlag(existingGatewayAccountId, 'government_entity_document')
-        .should.be.fulfilled
-        .notify(done)
+    it('should update successfully', (done) => {
+      connectorClient
+        .setStripeAccountSetupFlag(existingGatewayAccountId, 'government_entity_document')
+        .should.be.fulfilled.notify(done)
     })
   })
 })

--- a/test/pact/ledger-client/ledger-pact-test-provider.js
+++ b/test/pact/ledger-client/ledger-pact-test-provider.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 
 const path = require('path')
 
@@ -10,7 +10,7 @@ const pactProvider = new Pact({
   log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
   dir: path.resolve(process.cwd(), 'pacts'),
   spec: 2,
-  pactfileWriteMode: 'merge'
+  pactfileWriteMode: 'merge',
 })
 module.exports = {
   addInteraction: function (pact) {
@@ -24,5 +24,5 @@ module.exports = {
   },
   finalize: function () {
     return pactProvider.finalize()
-  }
+  },
 }

--- a/test/pact/products-client/payment/create.pact.test.js
+++ b/test/pact/products-client/payment/create.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -13,11 +13,11 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 const PRODUCTS_RESOURCE = '/v1/api/products'
 let result, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -28,7 +28,7 @@ describe('products client - creating a new payment', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -42,16 +42,17 @@ describe('products client - creating a new payment', () => {
     const response = productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId })
 
     before((done) => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
-          .withUponReceiving('a valid create charge create request')
-          .withMethod('POST')
-          .withStatusCode(201)
-          .withResponseBody(pactify(response))
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
+            .withUponReceiving('a valid create charge create request')
+            .withMethod('POST')
+            .withStatusCode(201)
+            .withResponseBody(pactify(response))
+            .build()
+        )
         .then(() => productsClient.payment.create(productExternalId))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
@@ -67,24 +68,33 @@ describe('products client - creating a new payment', () => {
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')
-      expect(result.links.self).to.have.property('method').to.equal(response._links.find(link => link.rel === 'self').method)
-      expect(result.links.self).to.have.property('href').to.equal(response._links.find(link => link.rel === 'self').href)
+      expect(result.links.self)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'self').method)
+      expect(result.links.self)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'self').href)
       expect(result.links).to.have.property('next')
-      expect(result.links.next).to.have.property('method').to.equal(response._links.find(link => link.rel === 'next').method)
-      expect(result.links.next).to.have.property('href').to.equal(response._links.find(link => link.rel === 'next').href)
+      expect(result.links.next)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'next').method)
+      expect(result.links.next)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'next').href)
     })
   })
 
   describe('when creating a charge using a malformed request', () => {
-    beforeEach(done => {
+    beforeEach((done) => {
       const productExternalId = 'invalid-id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
-          .withUponReceiving('an invalid create charge request')
-          .withMethod('POST')
-          .withStatusCode(400)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
+            .withUponReceiving('an invalid create charge request')
+            .withMethod('POST')
+            .withStatusCode(400)
+            .build()
+        )
         .then(() => productsClient.payment.create(productExternalId), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/pact/products-client/payment/get-by-payment-external-id.pact.test.js
+++ b/test/pact/products-client/payment/get-by-payment-external-id.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -13,11 +13,11 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 const PAYMENT_RESOURCE = '/v1/api/payments'
 let result, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -28,7 +28,7 @@ describe('products client - find a payment by its own external id', function () 
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -41,20 +41,21 @@ describe('products client - find a payment by its own external id', function () 
     const paymentExternalId = 'existing-id'
     const response = productFixtures.validCreatePaymentResponse({ external_id: paymentExternalId })
 
-    before(done => {
+    before((done) => {
       const interaction = new PactInteractionBuilder(`${PAYMENT_RESOURCE}/${paymentExternalId}`)
         .withUponReceiving('a valid get payment request')
         .withMethod('GET')
         .withStatusCode(200)
         .withResponseBody(pactify(response))
         .build()
-      provider.addInteraction(interaction)
+      provider
+        .addInteraction(interaction)
         .then(() => productsClient.payment.getByPaymentExternalId(paymentExternalId))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
-        .catch(e => done(e))
+        .catch((e) => done(e))
     })
 
     after(() => provider.verify())
@@ -67,24 +68,33 @@ describe('products client - find a payment by its own external id', function () 
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')
-      expect(result.links.self).to.have.property('method').to.equal(response._links.find(link => link.rel === 'self').method)
-      expect(result.links.self).to.have.property('href').to.equal(response._links.find(link => link.rel === 'self').href)
+      expect(result.links.self)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'self').method)
+      expect(result.links.self)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'self').href)
       expect(result.links).to.have.property('next')
-      expect(result.links.next).to.have.property('method').to.equal(response._links.find(link => link.rel === 'next').method)
-      expect(result.links.next).to.have.property('href').to.equal(response._links.find(link => link.rel === 'next').href)
+      expect(result.links.next)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'next').method)
+      expect(result.links.next)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'next').href)
     })
   })
 
   describe('when a product is not found', () => {
-    before(done => {
+    before((done) => {
       const paymentExternalId = 'non-existing-id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${PAYMENT_RESOURCE}/${paymentExternalId}`)
-          .withUponReceiving('a valid find payment request with non existing id')
-          .withMethod('GET')
-          .withStatusCode(404)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${PAYMENT_RESOURCE}/${paymentExternalId}`)
+            .withUponReceiving('a valid find payment request with non existing id')
+            .withMethod('GET')
+            .withStatusCode(404)
+            .build()
+        )
         .then(() => productsClient.payment.getByPaymentExternalId(paymentExternalId), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/pact/products-client/payment/get-by-product-external-id.pact.test.js
+++ b/test/pact/products-client/payment/get-by-product-external-id.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -14,11 +14,11 @@ const { pactifySimpleArray } = require('../../../test-helpers/pact/pactifier').d
 const PRODUCT_RESOURCE = '/v1/api/products'
 let result, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -29,7 +29,7 @@ describe('products client - find a payment by its associated product external id
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -43,30 +43,31 @@ describe('products client - find a payment by its associated product external id
     const response = [
       productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId }),
       productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId }),
-      productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId })
+      productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId }),
     ]
 
-    before(done => {
+    before((done) => {
       const interaction = new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
         .withUponReceiving('a valid get payment by product request')
         .withMethod('GET')
         .withStatusCode(200)
         .withResponseBody(pactifySimpleArray(response))
         .build()
-      provider.addInteraction(interaction)
+      provider
+        .addInteraction(interaction)
         .then(() => productsClient.payment.getByProductExternalId(productExternalId))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
-        .catch(e => done(e))
+        .catch((e) => done(e))
     })
 
     after(() => provider.verify())
 
     it('should return a list of payments', () => {
       expect(result.length).to.equal(3)
-      expect(result.map(item => item.constructor)).to.deep.equal([Payment, Payment, Payment])
+      expect(result.map((item) => item.constructor)).to.deep.equal([Payment, Payment, Payment])
       result.forEach((payment, index) => {
         const result = response[index]
         expect(payment.productExternalId).to.equal(result.product_external_id).and.to.equal(productExternalId)
@@ -76,25 +77,34 @@ describe('products client - find a payment by its associated product external id
         expect(payment).to.have.property('links')
         expect(Object.keys(payment.links).length).to.equal(2)
         expect(payment.links).to.have.property('self')
-        expect(payment.links.self).to.have.property('method').to.equal(result._links.find(link => link.rel === 'self').method)
-        expect(payment.links.self).to.have.property('href').to.equal(result._links.find(link => link.rel === 'self').href)
+        expect(payment.links.self)
+          .to.have.property('method')
+          .to.equal(result._links.find((link) => link.rel === 'self').method)
+        expect(payment.links.self)
+          .to.have.property('href')
+          .to.equal(result._links.find((link) => link.rel === 'self').href)
         expect(payment.links).to.have.property('next')
-        expect(payment.links.next).to.have.property('method').to.equal(result._links.find(link => link.rel === 'next').method)
-        expect(payment.links.next).to.have.property('href').to.equal(result._links.find(link => link.rel === 'next').href)
+        expect(payment.links.next)
+          .to.have.property('method')
+          .to.equal(result._links.find((link) => link.rel === 'next').method)
+        expect(payment.links.next)
+          .to.have.property('href')
+          .to.equal(result._links.find((link) => link.rel === 'next').href)
       })
     })
   })
 
   describe('when a product is not found', () => {
-    before(done => {
+    before((done) => {
       const productExternalId = 'non-existing-id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
-          .withUponReceiving('a valid find product payments request with non existing id')
-          .withMethod('GET')
-          .withStatusCode(404)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
+            .withUponReceiving('a valid find product payments request with non existing id')
+            .withMethod('GET')
+            .withStatusCode(404)
+            .build()
+        )
         .then(() => productsClient.payment.getByProductExternalId(productExternalId), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/pact/products-client/product/create.pact.test.js
+++ b/test/pact/products-client/product/create.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -15,11 +15,11 @@ let result, productsClient
 
 const randomPrice = () => Math.round(Math.random() * 10000) + 1
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -30,7 +30,7 @@ describe('products client - create a new product', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -45,35 +45,38 @@ describe('products client - create a new product', () => {
       description: 'a test product',
       returnUrl: 'https://example.gov.uk/paid-for-somet',
       price: randomPrice(),
-      language
+      language,
     })
     const response = productFixtures.validProductResponse(request)
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(PRODUCT_RESOURCE)
-          .withUponReceiving('a valid create product request')
-          .withMethod('POST')
-          .withRequestBody(request)
-          .withStatusCode(201)
-          .withResponseBody(pactify(response))
-          .build()
-      )
-        .then(() => productsClient.product.create({
-          gatewayAccountId: request.gateway_account_id,
-          payApiToken: request.pay_api_token,
-          name: request.name,
-          price: request.price,
-          description: request.description,
-          returnUrl: request.return_url,
-          type: 'DEMO',
-          language
-        }))
-        .then(res => {
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(PRODUCT_RESOURCE)
+            .withUponReceiving('a valid create product request')
+            .withMethod('POST')
+            .withRequestBody(request)
+            .withStatusCode(201)
+            .withResponseBody(pactify(response))
+            .build()
+        )
+        .then(() =>
+          productsClient.product.create({
+            gatewayAccountId: request.gateway_account_id,
+            payApiToken: request.pay_api_token,
+            name: request.name,
+            price: request.price,
+            description: request.description,
+            returnUrl: request.return_url,
+            type: 'DEMO',
+            language,
+          })
+        )
+        .then((res) => {
           result = res
           done()
         })
-        .catch(e => done(e))
+        .catch((e) => done(e))
     })
 
     afterEach(() => provider.verify())
@@ -89,36 +92,49 @@ describe('products client - create a new product', () => {
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')
-      expect(result.links.self).to.have.property('method').to.equal(response._links.find(link => link.rel === 'self').method)
-      expect(result.links.self).to.have.property('href').to.equal(response._links.find(link => link.rel === 'self').href)
+      expect(result.links.self)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'self').method)
+      expect(result.links.self)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'self').href)
       expect(result.links).to.have.property('pay')
-      expect(result.links.pay).to.have.property('method').to.equal(response._links.find(link => link.rel === 'pay').method)
-      expect(result.links.pay).to.have.property('href').to.equal(response._links.find(link => link.rel === 'pay').href)
+      expect(result.links.pay)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'pay').method)
+      expect(result.links.pay)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'pay').href)
     })
   })
 
   describe('create a product - bad request', () => {
     const request = productFixtures.validCreateProductRequest({ pay_api_token: '' })
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(PRODUCT_RESOURCE)
-          .withUponReceiving('an invalid create product request')
-          .withMethod('POST')
-          .withRequestBody(request)
-          .withStatusCode(400)
-          .build()
-      )
-        .then(() => productsClient.product.create({
-          gatewayAccountId: request.gateway_account_id,
-          payApiToken: request.pay_api_token,
-          name: request.name,
-          price: request.price,
-          description: request.description,
-          returnUrl: request.return_url,
-          type: request.type,
-          language: request.language
-        }), done)
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(PRODUCT_RESOURCE)
+            .withUponReceiving('an invalid create product request')
+            .withMethod('POST')
+            .withRequestBody(request)
+            .withStatusCode(400)
+            .build()
+        )
+        .then(
+          () =>
+            productsClient.product.create({
+              gatewayAccountId: request.gateway_account_id,
+              payApiToken: request.pay_api_token,
+              name: request.name,
+              price: request.price,
+              description: request.description,
+              returnUrl: request.return_url,
+              type: request.type,
+              language: request.language,
+            }),
+          done
+        )
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {
           result = err

--- a/test/pact/products-client/product/delete.pact.test.js
+++ b/test/pact/products-client/product/delete.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -11,11 +11,11 @@ const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interact
 const API_RESOURCE = '/v1/api'
 let result, productExternalId, gatewayAccountId, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -26,7 +26,7 @@ describe('products client - delete a product', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -36,22 +36,25 @@ describe('products client - delete a product', () => {
   after(() => provider.finalize())
 
   describe('when a product is successfully deleted', () => {
-    before(done => {
+    before((done) => {
       gatewayAccountId = '999'
       productExternalId = 'a_valid_external_id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`)
-          .withUponReceiving('a valid delete product request')
-          .withMethod('DELETE')
-          .withStatusCode(204)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(
+            `${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`
+          )
+            .withUponReceiving('a valid delete product request')
+            .withMethod('DELETE')
+            .withStatusCode(204)
+            .build()
+        )
         .then(() => productsClient.product.delete(gatewayAccountId, productExternalId))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
-        .catch(e => done(e))
+        .catch((e) => done(e))
     })
 
     afterEach(() => provider.verify())
@@ -62,15 +65,18 @@ describe('products client - delete a product', () => {
   })
 
   describe('delete a product - bad request', () => {
-    before(done => {
+    before((done) => {
       productExternalId = 'a_non_existant_external_id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`)
-          .withUponReceiving('an invalid delete product request')
-          .withMethod('DELETE')
-          .withStatusCode(404)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(
+            `${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`
+          )
+            .withUponReceiving('an invalid delete product request')
+            .withMethod('DELETE')
+            .withStatusCode(404)
+            .build()
+        )
         .then(() => productsClient.product.delete(gatewayAccountId, productExternalId), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/pact/products-client/product/disable.pact.test.js
+++ b/test/pact/products-client/product/disable.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -11,11 +11,11 @@ const PactInteractionBuilder = require('../../../test-helpers/pact/pact-interact
 const API_RESOURCE = '/v1/api'
 let result, productExternalId, gatewayAccountId, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -26,7 +26,7 @@ describe('products client - disable a product', () => {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -36,22 +36,25 @@ describe('products client - disable a product', () => {
   after(() => provider.finalize())
 
   describe('when a product is successfully disabled', () => {
-    before(done => {
+    before((done) => {
       gatewayAccountId = '999'
       productExternalId = 'a_valid_external_id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`)
-          .withUponReceiving('a valid disable product request')
-          .withMethod('PATCH')
-          .withStatusCode(204)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(
+            `${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`
+          )
+            .withUponReceiving('a valid disable product request')
+            .withMethod('PATCH')
+            .withStatusCode(204)
+            .build()
+        )
         .then(() => productsClient.product.disable(gatewayAccountId, productExternalId))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
-        .catch(e => done(e))
+        .catch((e) => done(e))
     })
 
     afterEach(() => provider.verify())
@@ -62,15 +65,18 @@ describe('products client - disable a product', () => {
   })
 
   describe('create a product - bad request', () => {
-    before(done => {
+    before((done) => {
       productExternalId = 'a_non_existant_external_id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`)
-          .withUponReceiving('an invalid disable product request')
-          .withMethod('PATCH')
-          .withStatusCode(400)
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(
+            `${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}/disable`
+          )
+            .withUponReceiving('an invalid disable product request')
+            .withMethod('PATCH')
+            .withStatusCode(400)
+            .build()
+        )
         .then(() => productsClient.product.disable(gatewayAccountId, productExternalId), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/pact/products-client/product/get-by-gateway-account-id-and-type-with-metadata.pact.test.js
+++ b/test/pact/products-client/product/get-by-gateway-account-id-and-type-with-metadata.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -13,11 +13,11 @@ const { pactifySimpleArray } = require('../../../test-helpers/pact/pactifier').d
 const API_RESOURCE = '/v1/api'
 let result, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -28,7 +28,7 @@ describe('products client - find a product with metadata associated with a parti
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -41,9 +41,14 @@ describe('products client - find a product with metadata associated with a parti
     const gatewayAccountId = 42
     const productType = 'ADHOC'
     const response = [
-      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 1000, type: productType, metadata: { key: 'value' } })
+      productFixtures.validProductResponse({
+        gateway_account_id: gatewayAccountId,
+        price: 1000,
+        type: productType,
+        metadata: { key: 'value' },
+      }),
     ]
-    before(done => {
+    before((done) => {
       const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
         .withQuery('type', productType)
         .withUponReceiving('a valid get product with metadata by gateway account id and type request')
@@ -52,9 +57,10 @@ describe('products client - find a product with metadata associated with a parti
         .withStatusCode(200)
         .withResponseBody(pactifySimpleArray(response))
         .build()
-      provider.addInteraction(interaction)
+      provider
+        .addInteraction(interaction)
         .then(() => productsClient.product.getByGatewayAccountIdAndType(gatewayAccountId, productType))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
@@ -74,11 +80,19 @@ describe('products client - find a product with metadata associated with a parti
         expect(product).to.have.property('links')
         expect(Object.keys(product.links).length).to.equal(2)
         expect(product.links).to.have.property('self')
-        expect(product.links.self).to.have.property('method').to.equal(response[index]._links.find(link => link.rel === 'self').method)
-        expect(product.links.self).to.have.property('href').to.equal(response[index]._links.find(link => link.rel === 'self').href)
+        expect(product.links.self)
+          .to.have.property('method')
+          .to.equal(response[index]._links.find((link) => link.rel === 'self').method)
+        expect(product.links.self)
+          .to.have.property('href')
+          .to.equal(response[index]._links.find((link) => link.rel === 'self').href)
         expect(product.links).to.have.property('pay')
-        expect(product.links.pay).to.have.property('method').to.equal(response[index]._links.find(link => link.rel === 'pay').method)
-        expect(product.links.pay).to.have.property('href').to.equal(response[index]._links.find(link => link.rel === 'pay').href)
+        expect(product.links.pay)
+          .to.have.property('method')
+          .to.equal(response[index]._links.find((link) => link.rel === 'pay').method)
+        expect(product.links.pay)
+          .to.have.property('href')
+          .to.equal(response[index]._links.find((link) => link.rel === 'pay').href)
         expect(product.metadata).to.exist.and.to.have.property('key').equal(response[index].metadata.key)
       })
     })

--- a/test/pact/products-client/product/get-by-gateway-account-id-and-type.pact.test.js
+++ b/test/pact/products-client/product/get-by-gateway-account-id-and-type.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -13,11 +13,11 @@ const { pactifySimpleArray } = require('../../../test-helpers/pact/pactifier').d
 const API_RESOURCE = '/v1/api'
 let result, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -28,7 +28,7 @@ describe('products client - find products associated with a particular gateway a
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -43,10 +43,10 @@ describe('products client - find products associated with a particular gateway a
     const response = [
       productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 1000, type: productType }),
       productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 2000, type: productType }),
-      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 3000, type: productType })
+      productFixtures.validProductResponse({ gateway_account_id: gatewayAccountId, price: 3000, type: productType }),
     ]
 
-    before(done => {
+    before((done) => {
       const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
         .withQuery('type', productType)
         .withUponReceiving('a valid get product by gateway account id request')
@@ -55,9 +55,10 @@ describe('products client - find products associated with a particular gateway a
         .withStatusCode(200)
         .withResponseBody(pactifySimpleArray(response))
         .build()
-      provider.addInteraction(interaction)
+      provider
+        .addInteraction(interaction)
         .then(() => productsClient.product.getByGatewayAccountIdAndType(gatewayAccountId, productType))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
@@ -77,17 +78,25 @@ describe('products client - find products associated with a particular gateway a
         expect(product).to.have.property('links')
         expect(Object.keys(product.links).length).to.equal(2)
         expect(product.links).to.have.property('self')
-        expect(product.links.self).to.have.property('method').to.equal(response[index]._links.find(link => link.rel === 'self').method)
-        expect(product.links.self).to.have.property('href').to.equal(response[index]._links.find(link => link.rel === 'self').href)
+        expect(product.links.self)
+          .to.have.property('method')
+          .to.equal(response[index]._links.find((link) => link.rel === 'self').method)
+        expect(product.links.self)
+          .to.have.property('href')
+          .to.equal(response[index]._links.find((link) => link.rel === 'self').href)
         expect(product.links).to.have.property('pay')
-        expect(product.links.pay).to.have.property('method').to.equal(response[index]._links.find(link => link.rel === 'pay').method)
-        expect(product.links.pay).to.have.property('href').to.equal(response[index]._links.find(link => link.rel === 'pay').href)
+        expect(product.links.pay)
+          .to.have.property('method')
+          .to.equal(response[index]._links.find((link) => link.rel === 'pay').method)
+        expect(product.links.pay)
+          .to.have.property('href')
+          .to.equal(response[index]._links.find((link) => link.rel === 'pay').href)
       })
     })
   })
 
   describe('when no products are found', () => {
-    before(done => {
+    before((done) => {
       const gatewayAccountId = 98765
       const productType = 'PROTOTYPE'
       const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
@@ -97,13 +106,14 @@ describe('products client - find products associated with a particular gateway a
         .withStatusCode(200)
         .withResponseBody([])
         .build()
-      provider.addInteraction(interaction)
+      provider
+        .addInteraction(interaction)
         .then(() => productsClient.product.getByGatewayAccountIdAndType(gatewayAccountId, productType), done)
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
-        .catch(e => done(e))
+        .catch((e) => done(e))
     })
 
     after(() => provider.verify())

--- a/test/pact/products-client/product/get-by-product-external-id.pact.test.js
+++ b/test/pact/products-client/product/get-by-product-external-id.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -13,11 +13,11 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 const API_RESOURCE = '/v1/api'
 let result, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -28,7 +28,7 @@ describe('products client - find a product by its external id', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -47,21 +47,26 @@ describe('products client - find a product by its external id', function () {
       name: 'A Product Name',
       description: 'About this product',
       return_url: 'https://example.gov.uk',
-      type: 'DEMO'
+      type: 'DEMO',
     })
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`)
-          .withUponReceiving('a valid get product request by external id')
-          .withMethod('GET')
-          .withState('a product with external id existing-id and gateway account id 42 exists')
-          .withStatusCode(200)
-          .withResponseBody(pactify(response))
-          .build()
-      )
-        .then(() => productsClient.product.getByProductExternalIdAndGatewayAccountId(gatewayAccountId, productExternalId))
-        .then(res => {
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(
+            `${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`
+          )
+            .withUponReceiving('a valid get product request by external id')
+            .withMethod('GET')
+            .withState('a product with external id existing-id and gateway account id 42 exists')
+            .withStatusCode(200)
+            .withResponseBody(pactify(response))
+            .build()
+        )
+        .then(() =>
+          productsClient.product.getByProductExternalIdAndGatewayAccountId(gatewayAccountId, productExternalId)
+        )
+        .then((res) => {
           result = res
           done()
         })
@@ -80,27 +85,41 @@ describe('products client - find a product by its external id', function () {
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')
-      expect(result.links.self).to.have.property('method').to.equal(response._links.find(link => link.rel === 'self').method)
-      expect(result.links.self).to.have.property('href').to.equal(response._links.find(link => link.rel === 'self').href)
+      expect(result.links.self)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'self').method)
+      expect(result.links.self)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'self').href)
       expect(result.links).to.have.property('pay')
-      expect(result.links.pay).to.have.property('method').to.equal(response._links.find(link => link.rel === 'pay').method)
-      expect(result.links.pay).to.have.property('href').to.equal(response._links.find(link => link.rel === 'pay').href)
+      expect(result.links.pay)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'pay').method)
+      expect(result.links.pay)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'pay').href)
     })
   })
 
   describe('when a product is not found', () => {
-    before(done => {
+    before((done) => {
       const gatewayAccountId = 999
       const productExternalId = 'non-existing-id'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`)
-          .withUponReceiving('a valid find product request with non existing id')
-          .withMethod('GET')
-          .withStatusCode(404)
-          .withResponseHeaders({})
-          .build()
-      )
-        .then(() => productsClient.product.getByProductExternalIdAndGatewayAccountId(gatewayAccountId, productExternalId), done)
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(
+            `${API_RESOURCE}/gateway-account/${gatewayAccountId}/products/${productExternalId}`
+          )
+            .withUponReceiving('a valid find product request with non existing id')
+            .withMethod('GET')
+            .withStatusCode(404)
+            .withResponseHeaders({})
+            .build()
+        )
+        .then(
+          () => productsClient.product.getByProductExternalIdAndGatewayAccountId(gatewayAccountId, productExternalId),
+          done
+        )
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {
           result = err

--- a/test/pact/products-client/product/get-by-product-path.pact.test.js
+++ b/test/pact/products-client/product/get-by-product-path.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire')
 
@@ -13,11 +13,11 @@ const { pactify } = require('../../../test-helpers/pact/pactifier').defaultPacti
 const PRODUCT_RESOURCE = '/v1/api/products'
 let result, productsClient
 
-function getProductsClient (baseUrl) {
+function getProductsClient(baseUrl) {
   return proxyquire('@services/clients/products.client', {
     '@root/config': {
-      PRODUCTS_URL: baseUrl
-    }
+      PRODUCTS_URL: baseUrl,
+    },
   })
 }
 
@@ -28,7 +28,7 @@ describe('products client - find a product by its product path', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -48,23 +48,24 @@ describe('products client - find a product by its product path', function () {
       description: 'About this product',
       return_url: 'https://example.gov.uk',
       service_name_path: serviceNamePath,
-      product_name_path: productNamePath
+      product_name_path: productNamePath,
     })
 
-    before(done => {
-      provider.addInteraction(
-        new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
-          .withQuery('serviceNamePath', serviceNamePath)
-          .withQuery('productNamePath', productNamePath)
-          .withUponReceiving('a valid get product request by product path')
-          .withMethod('GET')
-          .withState('a product with path service-name-path/product-name-path exists')
-          .withStatusCode(200)
-          .withResponseBody(pactify(response))
-          .build()
-      )
+    before((done) => {
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
+            .withQuery('serviceNamePath', serviceNamePath)
+            .withQuery('productNamePath', productNamePath)
+            .withUponReceiving('a valid get product request by product path')
+            .withMethod('GET')
+            .withState('a product with path service-name-path/product-name-path exists')
+            .withStatusCode(200)
+            .withResponseBody(pactify(response))
+            .build()
+        )
         .then(() => productsClient.product.getByProductPath(serviceNamePath, productNamePath))
-        .then(res => {
+        .then((res) => {
           result = res
           done()
         })
@@ -82,31 +83,44 @@ describe('products client - find a product by its product path', function () {
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(3)
       expect(result.links).to.have.property('self')
-      expect(result.links.self).to.have.property('method').to.equal(response._links.find(link => link.rel === 'self').method)
-      expect(result.links.self).to.have.property('href').to.equal(response._links.find(link => link.rel === 'self').href)
+      expect(result.links.self)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'self').method)
+      expect(result.links.self)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'self').href)
       expect(result.links).to.have.property('pay')
-      expect(result.links.pay).to.have.property('method').to.equal(response._links.find(link => link.rel === 'pay').method)
-      expect(result.links.pay).to.have.property('href').to.equal(response._links.find(link => link.rel === 'pay').href)
+      expect(result.links.pay)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'pay').method)
+      expect(result.links.pay)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'pay').href)
       expect(result.links).to.have.property('friendly')
-      expect(result.links.friendly).to.have.property('method').to.equal(response._links.find(link => link.rel === 'friendly').method)
-      expect(result.links.friendly).to.have.property('href').to.equal(response._links.find(link => link.rel === 'friendly').href)
+      expect(result.links.friendly)
+        .to.have.property('method')
+        .to.equal(response._links.find((link) => link.rel === 'friendly').method)
+      expect(result.links.friendly)
+        .to.have.property('href')
+        .to.equal(response._links.find((link) => link.rel === 'friendly').href)
     })
   })
 
   describe('when a product is not found', () => {
-    before(done => {
+    before((done) => {
       const serviceNamePath = 'non-existing-service-name-path'
       const productNamePath = 'non-existing-product-name-path'
-      provider.addInteraction(
-        new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
-          .withQuery('serviceNamePath', serviceNamePath)
-          .withQuery('productNamePath', productNamePath)
-          .withUponReceiving('a valid find product request with non existing product path')
-          .withMethod('GET')
-          .withStatusCode(404)
-          .withResponseHeaders({})
-          .build()
-      )
+      provider
+        .addInteraction(
+          new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
+            .withQuery('serviceNamePath', serviceNamePath)
+            .withQuery('productNamePath', productNamePath)
+            .withUponReceiving('a valid find product request with non existing product path')
+            .withMethod('GET')
+            .withStatusCode(404)
+            .withResponseHeaders({})
+            .build()
+        )
         .then(() => productsClient.product.getByProductPath(serviceNamePath, productNamePath), done)
         .then(() => done(new Error('Promise unexpectedly resolved')))
         .catch((err) => {

--- a/test/pact/publicauth-client/get-tokens.pact.test.js
+++ b/test/pact/publicauth-client/get-tokens.pact.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 const path = require('path')
 const chai = require('chai')
 const { expect } = chai
@@ -18,11 +18,11 @@ chai.use(chaiAsPromised)
 
 let publicAuthClient
 
-function getPublicAuthClient (baseUrl) {
+function getPublicAuthClient(baseUrl) {
   return proxyquire('@services/clients/public-auth.client', {
     '@root/config': {
-      PUBLIC_AUTH_URL: baseUrl
-    }
+      PUBLIC_AUTH_URL: baseUrl,
+    },
   })
 }
 
@@ -33,7 +33,7 @@ describe('publicauth client - get tokens', function () {
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
     dir: path.resolve(process.cwd(), 'pacts'),
     spec: 2,
-    pactfileWriteMode: 'merge'
+    pactfileWriteMode: 'merge',
   })
 
   before(async () => {
@@ -44,7 +44,7 @@ describe('publicauth client - get tokens', function () {
 
   describe('success', () => {
     const params = {
-      accountId: 42
+      accountId: 42,
     }
 
     const getServiceAuthResponse = gatewayAccountFixtures.validGatewayAccountTokensResponse(params)

--- a/test/pact/webhooks-client/webhooks.pact.test.js
+++ b/test/pact/webhooks-client/webhooks.pact.test.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
-const { Pact } = require('@pact-foundation/pact')
+const { PactV2: Pact } = require('@pact-foundation/pact')
 
 const PactInteractionBuilder = require('../../test-helpers/pact/pact-interaction-builder').PactInteractionBuilder
 const { pactify } = require('../../test-helpers/pact/pactifier').defaultPactifier
@@ -20,7 +20,7 @@ const provider = new Pact({
   log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
   dir: path.resolve(process.cwd(), 'pacts'),
   spec: 2,
-  pactfileWriteMode: 'merge'
+  pactfileWriteMode: 'merge',
 })
 
 const serviceId = 'an-external-service-id'
@@ -58,11 +58,10 @@ describe('webhooks client', function () {
     afterEach(() => provider.verify())
 
     it('should get list of webhooks for a given service', () => {
-      return webhooksClient.webhooks(serviceId, gatewayAccountId, isLive, { baseUrl: webhooksUrl })
-        .then((response) => {
-          // asserts that the client has correctly formatted the request to match the stubbed fixture provider
-          expect(response[0].externalId).to.equal(webhookId)
-        })
+      return webhooksClient.webhooks(serviceId, gatewayAccountId, isLive, { baseUrl: webhooksUrl }).then((response) => {
+        // asserts that the client has correctly formatted the request to match the stubbed fixture provider
+        expect(response[0].externalId).to.equal(webhookId)
+      })
     })
   })
 
@@ -79,7 +78,7 @@ describe('webhooks client', function () {
             callback_url: callbackUrl,
             live: isLive,
             description,
-            subscriptions
+            subscriptions,
           })
           .withUponReceiving('a valid request for a new webhooks')
           .withState('service and environment provided')
@@ -93,7 +92,13 @@ describe('webhooks client', function () {
     afterEach(() => provider.verify())
 
     it('should submit details to create a webhook', () => {
-      return webhooksClient.createWebhook(serviceId, gatewayAccountId, isLive, { callback_url: callbackUrl, description, subscriptions, baseUrl: webhooksUrl })
+      return webhooksClient
+        .createWebhook(serviceId, gatewayAccountId, isLive, {
+          callback_url: callbackUrl,
+          description,
+          subscriptions,
+          baseUrl: webhooksUrl,
+        })
         .then((response) => {
           expect(response.external_id).to.equal(webhookId)
         })
@@ -118,11 +123,10 @@ describe('webhooks client', function () {
     afterEach(() => provider.verify())
 
     it('should get list of messages for webhook for a given service', () => {
-      return webhooksClient.messages(serviceId, { baseUrl: webhooksUrl, page, status })
-        .then((response) => {
-          // asserts that the client has correctly formatted the request to match the stubbed fixture provider
-          expect(response[0].external_id).to.equal(webhookId)
-        })
+      return webhooksClient.messages(serviceId, { baseUrl: webhooksUrl, page, status }).then((response) => {
+        // asserts that the client has correctly formatted the request to match the stubbed fixture provider
+        expect(response[0].external_id).to.equal(webhookId)
+      })
     })
   })
 })

--- a/test/test-helpers/pact/pact-base.js
+++ b/test/test-helpers/pact/pact-base.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
-const { Matchers } = require('@pact-foundation/pact')
-const { somethingLike, eachLike, term } = Matchers
+const { MatchersV2 } = require('@pact-foundation/pact')
+const { somethingLike, eachLike, term } = MatchersV2
 
 module.exports = function (options = {}) {
   const pactifySimpleArray = (arr) => {
@@ -21,7 +21,7 @@ module.exports = function (options = {}) {
 
   const pactify = (object) => {
     if (object instanceof Array) {
-      return object.map(o => pactify(o))
+      return object.map((o) => pactify(o))
     }
     const pactified = {}
     _.forIn(object, (value, key) => {
@@ -29,8 +29,8 @@ module.exports = function (options = {}) {
         pactified[key] = null
       } else if (options.array && options.array.indexOf(key) !== -1) {
         let length
-        if (options.length && options.length.find(lengthKey => lengthKey.key === key)) {
-          length = options.length.find(lengthKey => lengthKey.key === key).length
+        if (options.length && options.length.find((lengthKey) => lengthKey.key === key)) {
+          length = options.length.find((lengthKey) => lengthKey.key === key).length
         } else {
           length = value.length
         }
@@ -49,7 +49,7 @@ module.exports = function (options = {}) {
   const withPactified = (payload) => {
     return {
       getPlain: () => payload,
-      getPactified: () => pactify(payload)
+      getPactified: () => pactify(payload),
     }
   }
 
@@ -62,6 +62,6 @@ module.exports = function (options = {}) {
     pactifySimpleArray,
     pactifyNestedArray,
     pactify,
-    withPactified
+    withPactified,
   }
 }

--- a/test/test-helpers/pact/pact-interaction-builder.ts
+++ b/test/test-helpers/pact/pact-interaction-builder.ts
@@ -1,7 +1,7 @@
 import { InteractionObject } from '@pact-foundation/pact'
 import { HTTPMethod } from '@pact-foundation/pact/src/common/request'
 import { Headers, Query } from '@pact-foundation/pact/src/dsl/interaction'
-import { AnyTemplate, Matcher } from '@pact-foundation/pact/src/dsl/matchers'
+import { AnyTemplate, MatcherV2 as Matcher } from '@pact-foundation/pact/src/dsl/matchers'
 
 class PactInteractionBuilder {
   url: string

--- a/test/test-helpers/pact/pactify.ts
+++ b/test/test-helpers/pact/pactify.ts
@@ -1,6 +1,6 @@
-import { Matchers } from '@pact-foundation/pact'
+import { MatchersV2 } from '@pact-foundation/pact'
 import { AnyTemplate } from '@pact-foundation/pact/src/dsl/matchers'
-const { somethingLike } = Matchers
+const { somethingLike } = MatchersV2
 
 type Pactified = AnyTemplate
 


### PR DESCRIPTION
## What

PP-**15409**

- Bump PACT NPM modules
- Update import statements to use the V2 style tests.
  - This will ensure our tests continue to work.
  - In the future, we can consider updating the tests to use the new V4 style.
- Updated the way we publish the PACT tests inline with the new PACT 16 way of doing things.

### How
- Check the PACT tests are running on the deploy environment.

