### PR TITLE
PP-15483 Transactions list view persist filters

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions-detail.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions-detail.controller.ts
@@ -22,8 +22,10 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   // sort by most recent first
   events.sort((eventA, eventB) => (eventA.timestamp > eventB.timestamp ? -1 : 1))
 
+  const transactionFilters = req.session.transactionFilters as string
+
   return response(req, res, 'simplified-account/services/all-service-transactions/detail/index', {
-    backLink: formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, req.account.type),
+    backLink: `${formattedPathFor(paths.allServiceTransactions.simplifiedAccount.index, req.account.type)}${transactionFilters ? `?${transactionFilters}` : ''} `,
     events,
     transaction,
     dispute: disputes.length > 0 && disputes[0],

--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions.controller.ts
@@ -96,6 +96,8 @@ async function get(
   const showCsvDownload =
     transactionCountWithinRange || (hasQueryParams && results.total > LEDGER_TRANSACTION_COUNT_LIMIT)
 
+  req.session.transactionFilters = req.url.split('?')[1] || ''
+
   return response(req, res, 'simplified-account/home/all-service-transactions/index', {
     modeFilter,
     oppositeMode,

--- a/src/controllers/simplified-account/services/transactions/detail/transactions-detail.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/detail/transactions-detail.controller.ts
@@ -26,16 +26,19 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   // sort by most recent first
   events.sort((eventA, eventB) => (eventA.timestamp > eventB.timestamp ? -1 : 1))
 
+  const transactionFilters = req.session.transactionFilters as string
+
   return response(req, res, 'simplified-account/services/transactions/detail/index', {
-    backLink: formatServiceAndAccountPathsFor(
+    backLink: `${formatServiceAndAccountPathsFor(
       paths.simplifiedAccount.transactions.index,
       req.service.externalId,
       req.account.type
-    ),
+    )
+      }${transactionFilters ? `?${transactionFilters}` : ''} `,
     events,
     transaction,
     dispute: disputes.length > 0 && disputes[0],
-    pageID: `${transaction.createdDate.toFormat(TITLE_FRIENDLY_DATE_TIME)} - ${transaction.reference}`,
+    pageID: `${transaction.createdDate.toFormat(TITLE_FRIENDLY_DATE_TIME)} - ${transaction.reference} `,
     oldView: formatAccountPathsFor(
       paths.account.transactions.detail,
       req.account.externalId,

--- a/src/controllers/simplified-account/services/transactions/detail/transactions-detail.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/detail/transactions-detail.controller.ts
@@ -33,8 +33,7 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
       paths.simplifiedAccount.transactions.index,
       req.service.externalId,
       req.account.type
-    )
-      }${transactionFilters ? `?${transactionFilters}` : ''} `,
+    )}${transactionFilters ? `?${transactionFilters}` : ''} `,
     events,
     transaction,
     dispute: disputes.length > 0 && disputes[0],

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -76,6 +76,8 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
   const showCsvDownload =
     transactionCountWithinRange || (hasQueryParams && results.total > LEDGER_TRANSACTION_COUNT_LIMIT)
 
+  req.session.transactionFilters = req.url.split('?')[1] || ''
+
   return response(req, res, 'simplified-account/transactions/index', {
     results,
     isBST: isBritishSummerTime(),

--- a/src/utils/types/express/AuthenticatedRequest.ts
+++ b/src/utils/types/express/AuthenticatedRequest.ts
@@ -1,6 +1,8 @@
 import express from 'express'
 import User from '@models/user/User.class'
+import ClientSessionsCookie from '../client-sessions/ClientSessionsCookie'
 
 export interface AuthenticatedRequest extends express.Request {
-  user: User
+  user: User,
+  session: ClientSessionsCookie
 }

--- a/src/utils/types/express/AuthenticatedRequest.ts
+++ b/src/utils/types/express/AuthenticatedRequest.ts
@@ -3,6 +3,6 @@ import User from '@models/user/User.class'
 import ClientSessionsCookie from '../client-sessions/ClientSessionsCookie'
 
 export interface AuthenticatedRequest extends express.Request {
-  user: User,
+  user: User
   session: ClientSessionsCookie
 }

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transactions-detail.cy.ts
@@ -57,7 +57,6 @@ const userAndGatewayAccountStubs = [
 
 describe('All services transaction details page', () => {
   beforeEach(() => {
-    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
@@ -74,11 +73,13 @@ describe('All services transaction details page', () => {
   })
 
   it('accessibility check', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.visit(ALL_SERVICES_TRANSACTION_URL)
     cy.a11yCheck()
   })
 
   it('should display correct page title and headings', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.visit(ALL_SERVICES_TRANSACTION_URL)
 
     cy.title().should('eq', `Transaction details - 22 Jul 2025 03:14:15 - ${TRANSACTION.reference} - GOV.UK Pay`)
@@ -86,6 +87,7 @@ describe('All services transaction details page', () => {
   })
 
   it('should navigate to transactions list page when back link is clicked', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
         serviceExternalId: SERVICE_EXTERNAL_ID,
@@ -100,7 +102,26 @@ describe('All services transaction details page', () => {
     cy.url().should('include', ALL_SERVICES_TRANSACTIONS_LIST_URL)
   })
 
+  it('should persist filters when back link is clicked', () => {
+    const filters = { transactionFilters: '&state=success&dateFilter=last-12-months' }
+
+    cy.setEncryptedCookies(USER_EXTERNAL_ID, filters)
+    cy.task('setupStubs', [
+      gatewayAccountStubs.getGatewayAccountByServiceIdsSuccess({
+        serviceExternalId: SERVICE_EXTERNAL_ID,
+        type: 'test',
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+      }),
+    ])
+
+    cy.visit(ALL_SERVICES_TRANSACTION_URL)
+    cy.get('.govuk-back-link').click()
+
+    cy.url().should('include', ALL_SERVICES_TRANSACTIONS_LIST_URL + `?` + filters.transactionFilters)
+  })
+
   it('should navigate to all services refund page when button is clicked', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.visit(ALL_SERVICES_TRANSACTION_URL)
 
     cy.contains('a.govuk-button', 'Refund payment').should('be.visible').click()

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -72,11 +72,8 @@ const userAndGatewayAccountStubs = [
 ]
 
 describe('Transaction details page', () => {
-  beforeEach(() => {
-    cy.setEncryptedCookies(USER_EXTERNAL_ID)
-  })
-
   it('accessibility check', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
@@ -87,6 +84,7 @@ describe('Transaction details page', () => {
   })
 
   it('should display correct page title and headings', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
@@ -107,6 +105,7 @@ describe('Transaction details page', () => {
   })
 
   it('should navigate to transactions list page when back link is clicked', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
@@ -127,7 +126,31 @@ describe('Transaction details page', () => {
     cy.url().should('include', TRANSACTIONS_LIST_URL)
   })
 
+  it('should persist filters when back link is clicked', () => {
+    const filters = { transactionFilters: '&state=success&dateFilter=last-12-months' }
+    cy.setEncryptedCookies(USER_EXTERNAL_ID, filters)
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
+      getCardTypesSuccess(),
+      transactionStubs.getLedgerTransactionsSuccess({
+        gatewayAccountId: GATEWAY_ACCOUNT_ID,
+        transactions: [TRANSACTION],
+        filters: { from_date: TimeConstants.TWELVE_MONTHS_AGO.toUTC().toISO() },
+        displaySize: 20,
+        transactionLength: 1,
+      }),
+    ])
+
+    cy.visit(TRANSACTION_URL)
+    cy.get('.govuk-back-link').click()
+
+    cy.url().should('include', TRANSACTIONS_LIST_URL + `?` + filters.transactionFilters)
+  })
+
   it('should display transaction details correctly for a payment', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
@@ -255,6 +278,7 @@ describe('Transaction details page', () => {
     })
     const transactionWithRefund = new TransactionFixture({ refundSummary })
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, transactionWithRefund.externalId).success(
@@ -279,6 +303,7 @@ describe('Transaction details page', () => {
   it('should not display card details type when not present', () => {
     const transactionWithoutCardDetails = new TransactionFixture({ cardDetails: undefined })
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(
@@ -306,6 +331,7 @@ describe('Transaction details page', () => {
       }),
     })
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(transactionWith3DSRequired),
@@ -326,6 +352,7 @@ describe('Transaction details page', () => {
       authorisationSummary: new AuthorisationSummaryFixture(),
     })
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(
@@ -345,6 +372,8 @@ describe('Transaction details page', () => {
 
   it('should display wallet type when present', () => {
     const transactionWithWalletType = new TransactionFixture({ walletType: 'APPLE_PAY' })
+
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(transactionWithWalletType),
@@ -363,6 +392,8 @@ describe('Transaction details page', () => {
   it('should display fees when present', () => {
     const transactionAmounts = { corporateCardSurcharge: 25, fee: 15, totalAmount: 1075 }
     const transactionWithFees = new TransactionFixture({ ...transactionAmounts })
+
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(transactionWithFees),
@@ -409,6 +440,7 @@ describe('Transaction details page', () => {
 
     const transactionFee = penceToPoundsWithCurrency(disputeTransaction.fee)
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       transactionStubs.getLedgerTransactionSuccess({
@@ -542,6 +574,7 @@ describe('Transaction details page', () => {
       }),
     ]
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(declinedTransaction),
@@ -580,6 +613,7 @@ describe('Transaction details page', () => {
   })
 
   it('should navigate to refund page', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
@@ -597,6 +631,7 @@ describe('Transaction details page', () => {
     const refundUnavailableState = new LedgerRefundSummaryFixture({ status: RefundSummaryStatus.UNAVAILABLE })
     const transactionWithRefundUnavailable = new TransactionFixture({ refundSummary: refundUnavailableState })
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(
@@ -612,6 +647,7 @@ describe('Transaction details page', () => {
     const transactionCreatedTimestamp = DateTime.now().minus({ years: 7, months: 1 })
     const oldTransaction = new TransactionFixture({ createdDate: transactionCreatedTimestamp })
 
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
     cy.task('setupStubs', [
       ...userAndGatewayAccountStubs,
       getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(oldTransaction),


### PR DESCRIPTION
## What

PP-15483

- Make previously selected filters persist when navigating from transaction detail view to transaction list view
- Applies to both service level and all service transaction pages

### How

- From the all service, or service level transaction list page, select one or more filters
- Navigate to an individual transaction
- Click the `Back to transactions` link
- The URL should include the filters you previously selected, and the list should include filtered transactions only, NOT all transactions
