### PR TITLE
PP-15485 Update links from all service transactions refund

### DIFF
--- a/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions-refund.controller.ts
+++ b/src/controllers/simplified-account/home/all-service-transactions/all-service-transactions-refund.controller.ts
@@ -49,7 +49,7 @@ async function post(req: ServiceRequest<TransactionRefundBody>, res: ServiceResp
   if (transaction.isFullyRefunded() || !transaction.isRefundable()) {
     return res.redirect(
       formatServiceAndAccountPathsFor(
-        paths.simplifiedAccount.transactions.detail,
+        paths.simplifiedAccount.allServiceTransactions.detail,
         req.service.externalId,
         req.account.type,
         req.params.transactionExternalId
@@ -66,14 +66,14 @@ async function post(req: ServiceRequest<TransactionRefundBody>, res: ServiceResp
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     const formattedErrors = formatValidationErrors(errors)
-    return response(req, res, 'simplified-account/services/transactions/refund', {
+    return response(req, res, 'simplified-account/services/all-service-transactions/refund', {
       transaction,
       errors: {
         summary: formattedErrors.errorSummary,
         formErrors: formattedErrors.formErrors,
       },
       backLink: formatServiceAndAccountPathsFor(
-        paths.simplifiedAccount.transactions.detail,
+        paths.simplifiedAccount.allServiceTransactions.detail,
         req.service.externalId,
         req.account.type,
         req.params.transactionExternalId
@@ -107,7 +107,7 @@ async function post(req: ServiceRequest<TransactionRefundBody>, res: ServiceResp
 
   return res.redirect(
     formatServiceAndAccountPathsFor(
-      paths.simplifiedAccount.transactions.detail,
+      paths.simplifiedAccount.allServiceTransactions.detail,
       req.service.externalId,
       req.account.type,
       req.params.transactionExternalId

--- a/src/views/simplified-account/services/all-service-transactions/detail/refund.njk
+++ b/src/views/simplified-account/services/all-service-transactions/detail/refund.njk
@@ -20,7 +20,7 @@
         text: "£"
       },
       label: {
-        html: 'All services Refund amount <span class="govuk-visually-hidden">in &pound;</span>'
+        html: 'Refund amount <span class="govuk-visually-hidden">in &pound;</span>'
       },
       classes: 'govuk-input--width-10',
       errorMessage: { text: errors.formErrors['partialRefundAmount'] } if errors.formErrors['partialRefundAmount'] else false

--- a/test/cypress/integration/simplified-account/all-service-transactions/all-service-transaction-refund.cy.ts
+++ b/test/cypress/integration/simplified-account/all-service-transactions/all-service-transaction-refund.cy.ts
@@ -5,10 +5,12 @@ import { TransactionFixture } from '@test/fixtures/transaction/transaction.fixtu
 import {
   getTransactionEvents,
   getTransactionForGatewayAccount,
+  postRefund,
 } from '@test/cypress/stubs/simplified-account/transaction-stubs'
 import { TransactionEventFixture } from '@test/fixtures/transaction/transaction-event.fixture'
 import ROLES from '@test/fixtures/roles.fixtures'
 import { DateTime } from 'luxon'
+import { penceToPoundsWithCurrency } from '@utils/currency-formatter'
 
 const TRANSACTION_CREATED_TIMESTAMP = DateTime.fromISO('2025-07-22T03:14:15.926+01:00')
 const TRANSACTION = new TransactionFixture({ createdDate: TRANSACTION_CREATED_TIMESTAMP })
@@ -81,6 +83,38 @@ describe('All services refund page', () => {
 
     cy.visit(TRANSACTION_REFUND_URL)
     cy.get('.govuk-back-link').click()
+
+    cy.url().should('include', TRANSACTION_DETAIL_URL)
+  })
+
+  it('should navigate to transaction detail page when refund is made', () => {
+    const refundAmount = TRANSACTION.amount
+
+    cy.task('setupStubs', [
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
+      postRefund(SERVICE_EXTERNAL_ID, TRANSACTION.externalId).success(
+        refundAmount,
+        TRANSACTION,
+        USER_EXTERNAL_ID,
+        USER_EMAIL
+      ),
+    ])
+
+    cy.visit(TRANSACTION_REFUND_URL)
+
+    cy.get('#refund-payment').check()
+    cy.get('.govuk-radios__hint')
+      .first()
+      .should(
+        'contain',
+        `Refund the full amount of ${penceToPoundsWithCurrency(TRANSACTION.refundSummary.amountAvailable)}`
+      )
+    cy.contains(' Confirm refund ').should('be.visible').click()
+    cy.get('.govuk-notification-banner--success')
+      .should('be.visible')
+      .and('contain', 'Refund successful')
+      .and('contain', 'It may take up to six days to process')
 
     cy.url().should('include', TRANSACTION_DETAIL_URL)
   })


### PR DESCRIPTION
## What

PP-15485

- Update links from all service transactions refund to correctly redirect to all service views

### How
- from the all service transactions view, select a transaction that is refundable (for example with a status of success)
- Click `Refund payment` button
- Select `Full amount` radio button
- Click `Confirm refund` button
- You should be directed to the all transactions refund page (with no side bar navigation) and a banner should display with text including `Refund successful`

