### PR TITLE
PP-15481 Add Transaction metadata to Transaction detail page

### DIFF
--- a/src/models/transaction/Transaction.class.ts
+++ b/src/models/transaction/Transaction.class.ts
@@ -43,6 +43,7 @@ class Transaction {
   readonly data: TransactionData
   readonly paymentDetails?: PaymentDetails
   readonly parentTransactionExternalId?: string
+  readonly metadata?: Record<string, string>
 
   readonly _locals: {
     links: TransactionLinksGenerator
@@ -79,6 +80,7 @@ class Transaction {
     this.data = data
     this.paymentDetails = data.payment_details && new PaymentDetails(data.payment_details)
     this.parentTransactionExternalId = data.parent_transaction_id
+    this.metadata = data.metadata
 
     this._locals = {
       links: new TransactionLinksGenerator(this.getRootTransactionId()),

--- a/src/models/transaction/dto/Transaction.dto.ts
+++ b/src/models/transaction/dto/Transaction.dto.ts
@@ -42,4 +42,5 @@ export interface TransactionData {
   reason?: string // dispute only
   payment_details?: PaymentDetailsData
   parent_transaction_id?: string
+  metadata?: Record<string, string>
 }

--- a/src/views/simplified-account/services/all-service-transactions/detail/index.njk
+++ b/src/views/simplified-account/services/all-service-transactions/detail/index.njk
@@ -31,5 +31,8 @@
   {% if transaction.isDispute() or transaction.disputed %}
     {% include '../../transactions/detail/partials/_dispute-details.njk' %}
   {% endif %}
+  {% if transaction.metadata %}
+    {% include './partials/_metadata.njk' %}
+  {% endif %}
   {% include '../../transactions/detail/partials/_transaction-events.njk' %}
 {% endblock %}

--- a/src/views/simplified-account/services/transactions/detail/index.njk
+++ b/src/views/simplified-account/services/transactions/detail/index.njk
@@ -34,6 +34,9 @@
   {% if transaction.isDispute() or transaction.disputed %}
     {% include './partials/_dispute-details.njk' %}
   {% endif %}
+  {% if transaction.metadata %}
+    {% include './partials/_metadata.njk' %}
+  {% endif %}
   {% include './partials/_transaction-events.njk' %}
 
   <a class="govuk-button govuk-button--secondary" href="{{ oldView }}">GOTO old view</a>

--- a/src/views/simplified-account/services/transactions/detail/partials/_metadata.njk
+++ b/src/views/simplified-account/services/transactions/detail/partials/_metadata.njk
@@ -1,0 +1,15 @@
+<h2 class="govuk-heading-m govuk-!-margin-top-8">Metadata</h2>
+{% set metadataRows = [] %}
+{% for metadataKey, metadataValue in transaction.metadata | dictsort %}
+  {%
+    set metadataRows = metadataRows.concat({
+      key: {
+        text: metadataKey
+      },
+      value: {
+        text: metadataValue
+      }
+    })
+  %}
+{% endfor %}
+{{ govukSummaryList({ rows: metadataRows }) }}

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -530,6 +530,57 @@ describe('Transaction details page', () => {
       })
   })
 
+  it('should display transaction metadata when present', () => {
+    const transactionWithMetadata = new TransactionFixture({
+      metadata: {
+        'Metadata 1': 'This is some metadata',
+        'Metadata 2': 'This is some more metadata',
+      },
+    })
+
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(transactionWithMetadata),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
+    ])
+    cy.visit(TRANSACTION_URL)
+
+    cy.get('.govuk-heading-m')
+      .contains('Metadata')
+      .next()
+      .should('have.class', 'govuk-summary-list')
+      .within(() => {
+        cy.get('.govuk-summary-list__row')
+          .eq(0)
+          .within(() => {
+            cy.get('.govuk-summary-list__key').should('contain.text', 'Metadata 1')
+            cy.get('.govuk-summary-list__value').should('contain.text', 'This is some metadata')
+          })
+
+        cy.get('.govuk-summary-list__row')
+          .eq(1)
+          .within(() => {
+            cy.get('.govuk-summary-list__key').should('contain.text', 'Metadata 2')
+            cy.get('.govuk-summary-list__value').should('contain.text', 'This is some more metadata')
+          })
+      })
+  })
+
+  it('should not display metadata when none is present', () => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+    cy.task('setupStubs', [
+      ...userAndGatewayAccountStubs,
+      getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(
+        new TransactionFixture({ metadata: undefined })
+      ),
+      getTransactionEvents(GATEWAY_ACCOUNT_ID, TRANSACTION.externalId).success(TRANSACTION_EVENTS),
+    ])
+    cy.visit(TRANSACTION_URL)
+
+    cy.get('.govuk-heading-m').should('not.contain.text', 'Metadata')
+  })
+
   it('should display events', () => {
     const state = new TransactionStateFixture({ status: Status.DECLINED })
     const transactionAmount = 12345

--- a/test/fixtures/transaction/transaction.fixture.ts
+++ b/test/fixtures/transaction/transaction.fixture.ts
@@ -45,6 +45,7 @@ export class TransactionFixture {
   agreementId: string
   paymentDetails?: PaymentDetailsFixture
   parentTransactionExternalId?: string
+  metadata?: Record<string, string>
 
   constructor(options?: Partial<TransactionFixture>) {
     this.gatewayAccountId = '100'
@@ -113,6 +114,7 @@ export class TransactionFixture {
       authorisation_summary: this.authorisationSummary?.toAuthorisationSummaryData(),
       payment_details: this.paymentDetails?.toPaymentDetailsData(),
       parent_transaction_id: this.parentTransactionExternalId,
+      metadata: this.metadata,
     }
   }
 


### PR DESCRIPTION
## What

PP-15481

- add Transaction metadata to Transaction details page
- Metadata section will only be displayed if there is metadata on the transaction

### Screenshots (views have been added/changed)
<img width="1241" height="2013" alt="Screenshot 2026-06-17 at 10-57-08 Transaction details - 17 Jun 2026 10 37 31 - DD5SJS26FA - Transactions Service - GOV UK Pay" src="https://github.com/user-attachments/assets/8644d79c-63f6-4b92-bab8-084dbe0a8919" />
