### PR TITLE
PP-15481 Add content for payments which are non-refundable due to being disputed

### DIFF
--- a/src/models/transaction/Transaction.class.ts
+++ b/src/models/transaction/Transaction.class.ts
@@ -6,7 +6,12 @@ import { LedgerRefundSummary } from '@models/common/refund-summary/LedgerRefundS
 import { SettlementSummary } from '@models/common/settlement-summary/SettlementSummary.class'
 import { CardDetails } from '@models/common/card-details/CardDetails.class'
 import { ResourceType } from './types/resource-type'
-import { DisputeStatusFriendlyNames, PaymentStatusFriendlyNames, RefundStatusFriendlyNames } from './types/status'
+import {
+  DisputeStatusFriendlyNames,
+  PaymentStatusFriendlyNames,
+  RefundStatusFriendlyNames,
+  Status,
+} from './types/status'
 import { State } from './State.class'
 import { parseReason, Reason } from './types/reason'
 import { RefundSummaryStatus } from '@models/common/refund-summary/RefundSummaryStatus'
@@ -115,6 +120,16 @@ class Transaction {
 
   isDispute(): boolean {
     return this.transactionType === ResourceType.DISPUTE
+  }
+
+  isDisputePending(): boolean {
+    return (
+      this.isDispute() && (this.state.status === Status.NEEDS_RESPONSE || this.state.status === Status.UNDER_REVIEW)
+    )
+  }
+
+  isDisputeLost(): boolean {
+    return this.isDispute() && this.state.status === Status.LOST
   }
 
   hasRefund(): boolean {

--- a/src/views/simplified-account/services/all-service-transactions/detail/index.njk
+++ b/src/views/simplified-account/services/all-service-transactions/detail/index.njk
@@ -23,6 +23,12 @@
         href: transaction._locals.links.refund
       })
     }}
+  {% elif dispute and dispute.isDisputePending() %}
+    <p class="govuk-body">You cannot refund this payment because it is being disputed.</p>
+  {% elif dispute and dispute.isDisputeLost() %}
+    <p class="govuk-body"
+      >You cannot refund this payment because it was disputed and the paying user won the dispute.</p
+    >
   {% endif %}
   {% include '../../transactions/detail/partials/_details.njk' %}
   {% include '../../transactions/detail/partials/_amount.njk' %}

--- a/src/views/simplified-account/services/all-service-transactions/detail/index.njk
+++ b/src/views/simplified-account/services/all-service-transactions/detail/index.njk
@@ -26,9 +26,9 @@
   {% elif dispute and dispute.isDisputePending() %}
     <p class="govuk-body">You cannot refund this payment because it is being disputed.</p>
   {% elif dispute and dispute.isDisputeLost() %}
-    <p class="govuk-body"
-      >You cannot refund this payment because it was disputed and the paying user won the dispute.</p
-    >
+    <p class="govuk-body">
+      You cannot refund this payment because it was disputed and the paying user won the dispute.
+    </p>
   {% endif %}
   {% include '../../transactions/detail/partials/_details.njk' %}
   {% include '../../transactions/detail/partials/_amount.njk' %}

--- a/src/views/simplified-account/services/transactions/detail/index.njk
+++ b/src/views/simplified-account/services/transactions/detail/index.njk
@@ -9,8 +9,6 @@
 
 {% block serviceContent %}
   <h1 class="govuk-heading-l govuk-!-margin-top-6">Transaction details</h1>
-  {% include './partials/_details-page.njk' %}
-
   {% if isOverSevenYearsOld %}
     {{
       govukInsetText({

--- a/src/views/simplified-account/services/transactions/detail/index.njk
+++ b/src/views/simplified-account/services/transactions/detail/index.njk
@@ -28,9 +28,9 @@
   {% elif dispute and dispute.isDisputePending() %}
     <p class="govuk-body">You cannot refund this payment because it is being disputed.</p>
   {% elif dispute and dispute.isDisputeLost() %}
-    <p class="govuk-body"
-      >You cannot refund this payment because it was disputed and the paying user won the dispute.</p
-    >
+    <p class="govuk-body">
+      You cannot refund this payment because it was disputed and the paying user won the dispute.
+    </p>
   {% endif %}
   {% include './partials/_details.njk' %}
   {% include './partials/_amount.njk' %}

--- a/src/views/simplified-account/services/transactions/detail/index.njk
+++ b/src/views/simplified-account/services/transactions/detail/index.njk
@@ -9,6 +9,7 @@
 
 {% block serviceContent %}
   <h1 class="govuk-heading-l govuk-!-margin-top-6">Transaction details</h1>
+  {% include './partials/_details-page.njk' %}
 
   {% if isOverSevenYearsOld %}
     {{
@@ -29,7 +30,9 @@
   {% elif dispute and dispute.isDisputePending() %}
     <p class="govuk-body">You cannot refund this payment because it is being disputed.</p>
   {% elif dispute and dispute.isDisputeLost() %}
-    <p class="govuk-body">You cannot refund this payment because it has been disputed in the customer’s favour.</p>
+    <p class="govuk-body"
+      >You cannot refund this payment because it was disputed and the paying user won the dispute.</p
+    >
   {% endif %}
   {% include './partials/_details.njk' %}
   {% include './partials/_amount.njk' %}

--- a/src/views/simplified-account/services/transactions/detail/index.njk
+++ b/src/views/simplified-account/services/transactions/detail/index.njk
@@ -26,6 +26,10 @@
         href: transaction._locals.links.refund
       })
     }}
+  {% elif dispute and dispute.isDisputePending() %}
+    <p class="govuk-body">You cannot refund this payment because it is being disputed.</p>
+  {% elif dispute and dispute.isDisputeLost() %}
+    <p class="govuk-body">You cannot refund this payment because it has been disputed in the customer’s favour.</p>
   {% endif %}
   {% include './partials/_details.njk' %}
   {% include './partials/_amount.njk' %}

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -420,7 +420,7 @@ describe('Transaction details page', () => {
       })
   })
 
-  describe.only('for disputed payments', () => {
+  describe('for disputed payments', () => {
     const baseParent = new TransactionFixture(TRANSACTION, { disputed: true })
     const baseDispute = new TransactionFixture({
       gatewayAccountId: GATEWAY_ACCOUNT_ID,

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail.cy.ts
@@ -12,6 +12,7 @@ import { TransactionStateFixture } from '@test/fixtures/transaction/transaction-
 import { Reason, ReasonFriendlyNames } from '@models/transaction/types/reason'
 import { ResourceType } from '@models/transaction/types/resource-type'
 import {
+  getTransactionDisputes,
   getTransactionEvents,
   getTransactionForGatewayAccount,
 } from '@test/cypress/stubs/simplified-account/transaction-stubs'
@@ -419,115 +420,265 @@ describe('Transaction details page', () => {
       })
   })
 
-  it('should display dispute information', () => {
-    const parentTransactionOfDispute = new TransactionFixture({ disputed: true }).toTransactionData()
-
-    const disputeTransaction = {
-      gateway_account_id: GATEWAY_ACCOUNT_ID,
+  describe.only('for disputed payments', () => {
+    const baseParent = new TransactionFixture(TRANSACTION, { disputed: true })
+    const baseDispute = new TransactionFixture({
+      gatewayAccountId: GATEWAY_ACCOUNT_ID,
       amount: 1000,
       fee: 100,
-      net_amount: 900,
-      finished: true,
-      status: Status.NEEDS_RESPONSE,
-      created_date: TRANSACTION_CREATED_TIMESTAMP.plus({ month: 4 }),
-      type: ResourceType.DISPUTE,
-      includePaymentDetails: true,
-      evidence_due_date: TRANSACTION_CREATED_TIMESTAMP.plus({ month: 5 }),
+      netAmount: 900,
+      createdDate: TRANSACTION_CREATED_TIMESTAMP.plus({ month: 4 }),
+      transactionType: ResourceType.DISPUTE,
+      evidenceDueDate: TRANSACTION_CREATED_TIMESTAMP.plus({ month: 5 }),
       reason: Reason.FRAUDULENT,
-      transaction_id: parentTransactionOfDispute.gateway_transaction_id + '1a',
-      parent_transaction_id: parentTransactionOfDispute,
-    }
+      externalId: baseParent.externalId + '1a',
+      parentTransactionExternalId: baseParent.externalId,
+    })
 
-    const transactionFee = penceToPoundsWithCurrency(disputeTransaction.fee)
-
-    cy.setEncryptedCookies(USER_EXTERNAL_ID)
-    cy.task('setupStubs', [
-      ...userAndGatewayAccountStubs,
-      transactionStubs.getLedgerTransactionSuccess({
-        gatewayAccountId: GATEWAY_ACCOUNT_ID,
-        transactionDetails: parentTransactionOfDispute,
-      }),
-      transactionStubs.getLedgerEventsSuccess({
-        gatewayAccountId: GATEWAY_ACCOUNT_ID,
-        transactionId: parentTransactionOfDispute.transaction_id,
-        events: [],
-      }),
-      transactionStubs.getLedgerDisputeTransactionsSuccess({
-        disputeTransactionsDetails: {
-          parent_transaction_id: parentTransactionOfDispute.transaction_id,
-          gateway_account_id: GATEWAY_ACCOUNT_ID,
-          transactions: [disputeTransaction],
-        },
-      }),
-    ])
-    cy.visit(TRANSACTION_URL)
-
-    cy.get('h2').should('contain.text', 'Dispute details')
-
-    cy.get('.govuk-summary-list__row')
-      .eq(15)
-      .within(() => {
-        cy.get('.govuk-summary-list__key').should('contain.text', 'Status')
-        cy.get('.govuk-summary-list__value').should('contain.text', DisputeStatusFriendlyNames[Status.NEEDS_RESPONSE])
+    it('should display dispute information', () => {
+      const parentTransaction = new TransactionFixture(baseParent, {
+        refundSummary: new LedgerRefundSummaryFixture({
+          status: 'unavailable',
+          amountAvailable: 0,
+        }),
+      })
+      const disputeTransaction = new TransactionFixture(baseDispute, {
+        state: new TransactionStateFixture({
+          finished: false,
+          status: Status.NEEDS_RESPONSE,
+        }),
       })
 
-    cy.get('.govuk-summary-list__row')
-      .eq(16)
-      .within(() => {
-        cy.get('.govuk-summary-list__key').should('contain.text', 'Date disputed')
-        cy.get('.govuk-summary-list__value').should(
+      const transactionFee = penceToPoundsWithCurrency(disputeTransaction.fee!)
+
+      cy.setEncryptedCookies(USER_EXTERNAL_ID)
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        transactionStubs.getLedgerTransactionSuccess({
+          gatewayAccountId: GATEWAY_ACCOUNT_ID,
+          transactionDetails: parentTransaction.toTransactionData(),
+        }),
+        transactionStubs.getLedgerEventsSuccess({
+          gatewayAccountId: GATEWAY_ACCOUNT_ID,
+          transactionId: parentTransaction.externalId,
+          events: [],
+        }),
+        getTransactionDisputes(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success([disputeTransaction]),
+      ])
+      cy.visit(TRANSACTION_URL)
+
+      cy.get('h2').should('contain.text', 'Dispute details')
+
+      cy.get('.govuk-summary-list__row')
+        .eq(15)
+        .within(() => {
+          cy.get('.govuk-summary-list__key').should('contain.text', 'Status')
+          cy.get('.govuk-summary-list__value').should('contain.text', DisputeStatusFriendlyNames[Status.NEEDS_RESPONSE])
+        })
+
+      cy.get('.govuk-summary-list__row')
+        .eq(16)
+        .within(() => {
+          cy.get('.govuk-summary-list__key').should('contain.text', 'Date disputed')
+          cy.get('.govuk-summary-list__value').should(
+            'contain.text',
+            `${disputeTransaction.createdDate.toFormat(DATE_TIME)} (GMT)`
+          )
+        })
+
+      cy.get('.govuk-summary-list__row')
+        .eq(17)
+        .within(() => {
+          cy.get('.govuk-summary-list__key').should('contain.text', 'Disputed amount')
+          cy.get('.govuk-summary-list__value').should(
+            'contain.text',
+            penceToPoundsWithCurrency(disputeTransaction.amount)
+          )
+        })
+
+      cy.get('.govuk-summary-list__row')
+        .eq(18)
+        .within(() => {
+          cy.get('.govuk-summary-list__key').should('contain.text', 'Provider dispute fee')
+          cy.get('.govuk-summary-list__value').should('contain.text', transactionFee)
+          cy.get('.govuk-details__summary-text').should('contain.text', 'What is this fee?')
+          cy.get('.govuk-details__text').contains(
+            `If you lose a payment dispute, Stripe will deduct the disputed amount and an additional ${transactionFee} dispute fee from your account.`
+          )
+        })
+
+      cy.get('.govuk-summary-list__row')
+        .eq(19)
+        .within(() => {
+          cy.get('.govuk-summary-list__key').should('contain.text', 'Dispute net amount')
+          cy.get('.govuk-summary-list__value').should(
+            'contain.text',
+            penceToPoundsWithCurrency(disputeTransaction.netAmount!)
+          )
+        })
+
+      cy.get('.govuk-summary-list__row')
+        .eq(20)
+        .within(() => {
+          cy.get('.govuk-summary-list__key').should('contain.text', 'Reason')
+          cy.get('.govuk-summary-list__value').should('contain.text', ReasonFriendlyNames.FRAUDULENT)
+        })
+
+      cy.get('.govuk-summary-list__row')
+        .eq(21)
+        .within(() => {
+          cy.get('.govuk-summary-list__key').should('contain.text', 'Evidence due by')
+          cy.get('.govuk-summary-list__value').should(
+            'contain.text',
+            disputeTransaction.evidenceDueDate!.toFormat(DATE_TIME)
+          )
+        })
+    })
+
+    it('should not show the refund button and have the correct content when a dispute is pending information', () => {
+      const parentTransaction = new TransactionFixture(baseParent, {
+        refundSummary: new LedgerRefundSummaryFixture({
+          status: 'unavailable',
+          amountAvailable: 0,
+        }),
+      })
+      const disputeTransaction = new TransactionFixture(baseDispute, {
+        state: new TransactionStateFixture({
+          finished: false,
+          status: Status.NEEDS_RESPONSE,
+        }),
+      })
+
+      cy.setEncryptedCookies(USER_EXTERNAL_ID)
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success(parentTransaction),
+        transactionStubs.getLedgerEventsSuccess({
+          gatewayAccountId: GATEWAY_ACCOUNT_ID,
+          transactionId: parentTransaction.externalId,
+          events: [],
+        }),
+        getTransactionDisputes(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success([disputeTransaction]),
+      ])
+      cy.visit(TRANSACTION_URL)
+
+      cy.get('.govuk-button').contains('Refund payment').should('not.exist')
+
+      cy.get('h1')
+        .contains('Transaction details')
+        .next()
+        .should('have.class', 'govuk-body')
+        .should('contain.text', 'You cannot refund this payment because it is being disputed.')
+    })
+
+    it('should not show the refund button and have the correct content when a dispute is awaiting review', () => {
+      const parentTransaction = new TransactionFixture(baseParent, {
+        refundSummary: new LedgerRefundSummaryFixture({
+          status: 'unavailable',
+          amountAvailable: 0,
+        }),
+      })
+      const disputeTransaction = new TransactionFixture(baseDispute, {
+        state: new TransactionStateFixture({
+          finished: false,
+          status: Status.UNDER_REVIEW,
+        }),
+      })
+
+      cy.setEncryptedCookies(USER_EXTERNAL_ID)
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success(parentTransaction),
+        transactionStubs.getLedgerEventsSuccess({
+          gatewayAccountId: GATEWAY_ACCOUNT_ID,
+          transactionId: parentTransaction.externalId,
+          events: [],
+        }),
+        getTransactionDisputes(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success([disputeTransaction]),
+      ])
+      cy.visit(TRANSACTION_URL)
+
+      cy.get('.govuk-button').contains('Refund payment').should('not.exist')
+
+      cy.get('h1')
+        .contains('Transaction details')
+        .next()
+        .should('have.class', 'govuk-body')
+        .should('contain.text', 'You cannot refund this payment because it is being disputed.')
+    })
+
+    it('should not show the refund button and have the correct content when a dispute is lost', () => {
+      const parentTransaction = new TransactionFixture(baseParent, {
+        refundSummary: new LedgerRefundSummaryFixture({
+          status: 'unavailable',
+          amountAvailable: 0,
+        }),
+      })
+      const disputeTransaction = new TransactionFixture(baseDispute, {
+        state: new TransactionStateFixture({
+          finished: false,
+          status: Status.LOST,
+        }),
+      })
+
+      cy.setEncryptedCookies(USER_EXTERNAL_ID)
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success(parentTransaction),
+        transactionStubs.getLedgerEventsSuccess({
+          gatewayAccountId: GATEWAY_ACCOUNT_ID,
+          transactionId: parentTransaction.externalId,
+          events: [],
+        }),
+        getTransactionDisputes(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success([disputeTransaction]),
+      ])
+      cy.visit(TRANSACTION_URL)
+
+      cy.get('.govuk-button').contains('Refund payment').should('not.exist')
+
+      cy.get('h1')
+        .contains('Transaction details')
+        .next()
+        .should('have.class', 'govuk-body')
+        .should(
           'contain.text',
-          `${disputeTransaction.created_date.toFormat(DATE_TIME)} (GMT)`
+          'You cannot refund this payment because it was disputed and the paying user won the dispute.'
         )
+    })
+
+    it('should show the refund button when a dispute is won', () => {
+      const parentTransaction = new TransactionFixture(baseParent, {
+        refundSummary: new LedgerRefundSummaryFixture({
+          status: 'available',
+          amountAvailable: baseParent.amount,
+        }),
+      })
+      const disputeTransaction = new TransactionFixture(baseDispute, {
+        state: new TransactionStateFixture({
+          finished: false,
+          status: Status.WON,
+        }),
       })
 
-    cy.get('.govuk-summary-list__row')
-      .eq(17)
-      .within(() => {
-        cy.get('.govuk-summary-list__key').should('contain.text', 'Disputed amount')
-        cy.get('.govuk-summary-list__value').should(
-          'contain.text',
-          penceToPoundsWithCurrency(disputeTransaction.amount)
-        )
-      })
+      cy.setEncryptedCookies(USER_EXTERNAL_ID)
+      cy.task('setupStubs', [
+        ...userAndGatewayAccountStubs,
+        getTransactionForGatewayAccount(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success(parentTransaction),
+        transactionStubs.getLedgerEventsSuccess({
+          gatewayAccountId: GATEWAY_ACCOUNT_ID,
+          transactionId: parentTransaction.externalId,
+          events: [],
+        }),
+        getTransactionDisputes(GATEWAY_ACCOUNT_ID, parentTransaction.externalId).success([disputeTransaction]),
+      ])
+      cy.visit(TRANSACTION_URL)
 
-    cy.get('.govuk-summary-list__row')
-      .eq(18)
-      .within(() => {
-        cy.get('.govuk-summary-list__key').should('contain.text', 'Provider dispute fee')
-        cy.get('.govuk-summary-list__value').should('contain.text', transactionFee)
-        cy.get('.govuk-details__summary-text').should('contain.text', 'What is this fee?')
-        cy.get('.govuk-details__text').contains(
-          `If you lose a payment dispute, Stripe will deduct the disputed amount and an additional ${transactionFee} dispute fee from your account.`
-        )
-      })
-
-    cy.get('.govuk-summary-list__row')
-      .eq(19)
-      .within(() => {
-        cy.get('.govuk-summary-list__key').should('contain.text', 'Dispute net amount')
-        cy.get('.govuk-summary-list__value').should(
-          'contain.text',
-          penceToPoundsWithCurrency(disputeTransaction.net_amount)
-        )
-      })
-
-    cy.get('.govuk-summary-list__row')
-      .eq(20)
-      .within(() => {
-        cy.get('.govuk-summary-list__key').should('contain.text', 'Reason')
-        cy.get('.govuk-summary-list__value').should('contain.text', ReasonFriendlyNames.FRAUDULENT)
-      })
-
-    cy.get('.govuk-summary-list__row')
-      .eq(21)
-      .within(() => {
-        cy.get('.govuk-summary-list__key').should('contain.text', 'Evidence due by')
-        cy.get('.govuk-summary-list__value').should(
-          'contain.text',
-          disputeTransaction.evidence_due_date.toFormat(DATE_TIME)
-        )
-      })
+      cy.get('h1')
+        .contains('Transaction details')
+        .next()
+        .should('have.class', 'govuk-button')
+        .should('contain.text', 'Refund payment')
+    })
   })
 
   it('should display transaction metadata when present', () => {

--- a/test/cypress/stubs/simplified-account/transaction-stubs.ts
+++ b/test/cypress/stubs/simplified-account/transaction-stubs.ts
@@ -79,6 +79,25 @@ function getTransactionEvents(gatewayAccountId: string, transactionExternalId: s
   }
 }
 
+function getTransactionDisputes(gatewayAccountId: string, transactionExternalId: string) {
+  const path = `/v1/transaction/${transactionExternalId}/transaction`
+
+  return {
+    success: function (disputes: TransactionFixture[]) {
+      return stubBuilder('GET', path, 200, {
+        query: {
+          gateway_account_id: gatewayAccountId,
+          transaction_type: 'DISPUTE',
+        },
+        response: {
+          parent_transaction_id: transactionExternalId,
+          transactions: disputes.map((dispute) => dispute.toTransactionData()),
+        },
+      })
+    },
+  }
+}
+
 function postRefund(serviceExternalId: string, transactionExternalId: string) {
   const path = `/v1/api/service/${serviceExternalId}/account/test/charges/${transactionExternalId}/refunds`
 
@@ -106,5 +125,6 @@ export {
   getTransactionForGatewayAccount,
   getTransactionsForGatewayAccount,
   getTransactionEvents,
+  getTransactionDisputes,
   postRefund,
 }

--- a/test/fixtures/transaction/transaction.fixture.ts
+++ b/test/fixtures/transaction/transaction.fixture.ts
@@ -47,7 +47,7 @@ export class TransactionFixture {
   parentTransactionExternalId?: string
   metadata?: Record<string, string>
 
-  constructor(options?: Partial<TransactionFixture>) {
+  constructor(...options: Partial<TransactionFixture>[]) {
     this.gatewayAccountId = '100'
     this.serviceExternalId = 'service-external-id-123-abc'
     this.externalId = 'transaction-external-id-123-abc'
@@ -73,9 +73,10 @@ export class TransactionFixture {
     this.agreementId = 'none'
     this.refundSummary = new LedgerRefundSummaryFixture()
     this.paymentDetails = new PaymentDetailsFixture()
-    if (options) {
-      Object.assign(this, options)
-    }
+
+    options.forEach((optionObject) => {
+      Object.assign(this, optionObject)
+    })
   }
 
   toTransactionData(): TransactionData {
@@ -108,7 +109,7 @@ export class TransactionFixture {
       agreement_id: this.agreementId,
       disputed: this.disputed,
       transaction_id: this.externalId,
-      evidence_due_date: this.evidenceDueDate ? this.evidenceDueDate.toISODate()! : undefined,
+      evidence_due_date: this.evidenceDueDate ? this.evidenceDueDate.toISO()! : undefined,
       reason: this.reason,
       refund_summary: this.refundSummary?.toLedgerRefundSummaryData(),
       authorisation_summary: this.authorisationSummary?.toAuthorisationSummaryData(),


### PR DESCRIPTION
## What

PP-15481
- add content on Transaction Detail page for disputed payments which are not refundable
- this is existing behaviour in the current Transactions pages, however the existing pages display the same content for all dispute states, specifically `You cannot refund this payment because it is being disputed.`
  - this adds slightly different content for payments where the dispute has been lost, and so it is no longer accurate to say the payment is _being_ disputed.

### Screenshots (views have been added/changed)
<img width="1248" height="631" alt="Screenshot 2026-06-17 at 15 01 01" src="https://github.com/user-attachments/assets/b71b875d-261b-480c-9f13-6d036618413f" />
