### PR TITLE
PP-15481 Fix bug with displayed dates & times changing in filters on search

### DIFF
--- a/src/utils/custom-nunjucks-filters/datetime.ts
+++ b/src/utils/custom-nunjucks-filters/datetime.ts
@@ -1,35 +1,31 @@
 import { DateTime } from 'luxon'
 
-const shortDate = (dateString: string) => {
-  const date = DateTime.fromISO(dateString)
-  if (!date.isValid) {
+const shortDate = (date?: DateTime) => {
+  if (!date?.isValid) {
     return ''
   }
 
   return date.toFormat('dd LLL yy')
 }
 
-const shortTime = (dateString: string) => {
-  const date = DateTime.fromISO(dateString)
-  if (!date.isValid) {
+const shortTime = (date?: DateTime) => {
+  if (!date?.isValid) {
     return ''
   }
 
   return date.toFormat('H:mm:ss')
 }
 
-const europeanDate = (dateString: string) => {
-  const date = DateTime.fromISO(dateString)
-  if (!date.isValid) {
+const europeanDate = (date?: DateTime) => {
+  if (!date?.isValid) {
     return ''
   }
 
-  return date.toFormat('dd/LL/yyyy')
+  return date?.toFormat('dd/LL/yyyy')
 }
 
-const zonedTime = (dateString: string) => {
-  const date = DateTime.fromISO(dateString).setZone('Europe/London')
-  if (!date.isValid) {
+const zonedTime = (date?: DateTime) => {
+  if (!date?.isValid) {
     return ''
   }
 


### PR DESCRIPTION
## What

PP-15481
There is a bug where dates and times in the text inputs on the Transactions list page change on searching for transactions
- The start date would go back one day
- both the start and end times would go back by one hour

This only happened for times during BST, and was seemingly caused by the dates being interpreted as BST, then formatted as UTC

This PR fixes this bug

### Screenshots (views have been added/changed)


https://github.com/user-attachments/assets/984e464d-8ee8-49ae-95ef-027d75157392

