### PR TITLE
PP-15440 Add Adyen fees page

### DIFF
--- a/src/controllers/policy/supported-policy-documents.js
+++ b/src/controllers/policy/supported-policy-documents.js
@@ -4,40 +4,45 @@
 // and AWS S3 Bucket document ids (:key)
 const supportedPolicyDocuments = [
   {
-    key: 'memorandum-of-understanding-for-crown-bodies',
+    key: 'memorandum-of-understanding-for-crown-bodies', //pragma: allowlist secret
     title: 'Pay memorandum of understanding',
-    template: 'policy/document/v2/memorandum-of-understanding-for-crown-bodies'
+    template: 'policy/document/v2/memorandum-of-understanding-for-crown-bodies',
   },
   {
     key: 'contract-for-non-crown-bodies',
     title: 'Pay contract',
-    template: 'policy/document/v2/contract-for-non-crown-bodies'
+    template: 'policy/document/v2/contract-for-non-crown-bodies',
   },
   {
     key: 'stripe-connected-account-agreement',
     title: 'Stripe Connected Account Agreement',
-    template: 'policy/document/v2/stripe-connected-account-agreement'
+    template: 'policy/document/v2/stripe-connected-account-agreement',
   },
   {
     key: 'pci-dss-attestation-of-compliance',
     title: 'Attestation of Compliance for PCI',
-    template: 'policy/document/pci-dss-attestation-of-compliance'
+    template: 'policy/document/pci-dss-attestation-of-compliance',
   },
   {
     key: 'memorandum-of-understanding-for-crown-bodies-2022',
     title: 'Pay memorandum of understanding from 21 February 2022',
-    template: 'policy/document/v2/memorandum-of-understanding-for-crown-bodies'
+    template: 'policy/document/v2/memorandum-of-understanding-for-crown-bodies',
   },
   {
     key: 'contract-for-non-crown-bodies-2022',
     title: 'Pay contract from 21 February 2022',
-    template: 'policy/document/v2/contract-for-non-crown-bodies'
+    template: 'policy/document/v2/contract-for-non-crown-bodies',
   },
   {
     key: 'stripe-connected-account-agreement-2022',
     title: 'Stripe Connected Account Agreement from 21 February 2022',
-    template: 'policy/document/v2/stripe-connected-account-agreement'
-  }
+    template: 'policy/document/v2/stripe-connected-account-agreement',
+  },
+  {
+    key: 'adyen-fees-2026',
+    title: 'Adyen card fees',
+    template: 'settings/switch-psp/switch-to-adyen/adyen-fees',
+  },
 ]
 
 const supportedPolicyDocumentsKeyIndex = supportedPolicyDocuments.reduce((index, policyDocument) => {
@@ -45,7 +50,7 @@ const supportedPolicyDocumentsKeyIndex = supportedPolicyDocuments.reduce((index,
   return index
 }, {})
 
-const lookup = async function lookup (key) {
+const lookup = async function lookup(key) {
   const document = supportedPolicyDocumentsKeyIndex[key]
 
   if (!document) {

--- a/src/controllers/simplified-account/settings/switch-psp/index.js
+++ b/src/controllers/simplified-account/settings/switch-psp/index.js
@@ -1,3 +1,4 @@
+module.exports.adyenFees = require('./switch-to-adyen/adyen-fees.controller')
 module.exports.providerChangeToAdyen = require('./switch-to-adyen/provider-change-to-adyen.controller')
 module.exports.switchToWorldpay = require('./switch-to-worldpay/switch-to-worldpay.controller')
 module.exports.switchToStripe = require('./switch-to-stripe/switch-to-stripe.controller')

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees.controller.test.js
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees.controller.test.js
@@ -1,0 +1,69 @@
+const sinon = require('sinon')
+const ControllerTestBuilder = require('@test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class')
+const supportedPolicyDocuments = require('@controllers/policy/supported-policy-documents')
+
+const mockResponse = sinon.stub()
+
+const mockBucketGetLinkToPdf = sinon.spy(() => {
+  return new Promise((resolve) => {
+    resolve('html-url-link')
+  })
+})
+
+const mockBucketService = {
+  generatePrivateLink: mockBucketGetLinkToPdf,
+}
+
+const { req, res, next, nextRequest, nextResponse, call } = new ControllerTestBuilder(
+  '@controllers/simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees.controller'
+)
+  .withStubs({
+    '@utils/response': { response: mockResponse },
+    '@controllers/policy/aws-s3-policy-bucket': mockBucketService,
+  })
+  .build()
+
+let documentConfig
+
+describe('Controller: settings/switch-psp/switch-to-adyen/adyen-fees', () => {
+  before(async () => {
+    documentConfig = await supportedPolicyDocuments.lookup('adyen-fees-2026')
+  })
+  it('should call s3 policy bucket for private link and download document', async function () {
+    await call('get')
+    sinon.assert.calledWith(mockBucketService.generatePrivateLink, documentConfig)
+  })
+
+  it('should call the response method', async () => {
+    await call('get')
+    sinon.assert.calledOnce(mockResponse)
+    sinon.assert.notCalled(next)
+  })
+
+  it('should pass req, res and template path to the response method', async () => {
+    await call('get')
+    sinon.assert.calledWith(mockResponse, req, res, 'simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees')
+  })
+
+  it('should pass the context data to the response method', async () => {
+    await call('get')
+    const context = mockResponse.args[0][3]
+    sinon.assert.match(context, {
+      downloadLink: 'html-url-link',
+    })
+  })
+
+  it('should handle error', async () => {
+    mockBucketService.generatePrivateLink = sinon.spy(() => {
+      return new Promise((resolve, reject) => {
+        const error = new Error()
+        error.code = '404'
+        error.message = 'invalid path'
+        reject(error)
+      })
+    })
+    await call('get')
+    sinon.assert.notCalled(mockResponse)
+    sinon.assert.called(next)
+  })
+})

--- a/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees.controller.ts
+++ b/src/controllers/simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees.controller.ts
@@ -1,0 +1,28 @@
+import type { ServiceRequest, ServiceResponse } from '@utils/types/express'
+import { response } from '@utils/response'
+import policyBucket from '@controllers/policy/aws-s3-policy-bucket'
+import supportedPolicyDocuments from '@controllers/policy/supported-policy-documents'
+import createLogger from '@utils/logger'
+import { NextFunction } from 'express'
+
+const logger = createLogger(__filename)
+
+async function get(req: ServiceRequest, res: ServiceResponse, next: NextFunction) {
+  const key = 'adyen-fees-2026'
+  try {
+    const documentConfig: unknown = await supportedPolicyDocuments.lookup(key)
+    const downloadLink = await policyBucket.generatePrivateLink(documentConfig)
+
+    logger.info(`Generated link to download document - ${key}`)
+
+    return response(req, res, 'simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees', {
+      downloadLink,
+    })
+  } catch (err) {
+    next(err)
+  }
+}
+
+export = {
+  get,
+}

--- a/src/paths.js
+++ b/src/paths.js
@@ -267,7 +267,7 @@ module.exports = {
       switchPsp: {
         switchToAdyen: {
           providerChangeToAdyen: '/settings/switch-psp/switch-to-adyen/provider-change-to-adyen',
-          adyenFees: '/settings/switch-psp/switch-to-adyen/provider-change-to-adyen/adyen-fees',
+          adyenFees: '/settings/switch-psp/switch-to-adyen/adyen-fees',
         },
         switchToStripe: {
           index: '/settings/switch-psp/switch-to-stripe',

--- a/src/simplified-account-routes.js
+++ b/src/simplified-account-routes.js
@@ -809,6 +809,14 @@ simplifiedAccount.get(
   serviceSettingsController.switchPsp.providerChangeToAdyen.get
 )
 simplifiedAccount.get(
+  paths.simplifiedAccount.settings.switchPsp.switchToAdyen.adyenFees,
+  experimentalFeature(Features.PROVIDER_CHANGE_TO_ADYEN_LINK),
+  enforceLiveAccountOnly,
+  enforcePaymentProviderType(STRIPE),
+  permission('stripe-account-details:update'),
+  serviceSettingsController.switchPsp.adyenFees.get
+)
+simplifiedAccount.get(
   paths.simplifiedAccount.settings.switchPsp.switchToWorldpay.index,
   restrictToSwitchingAccount(WORLDPAY),
   permission('gateway-credentials:update'),

--- a/src/views/simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-adyen/adyen-fees.njk
@@ -1,0 +1,26 @@
+{% extends "simplified-account/settings/settings-layout.njk" %}
+
+
+{% set settingsPageTitle %}Adyen card fees{% endset %}
+
+{% block settingsContent %}
+  <h1 class="govuk-heading-l">{{ settingsPageTitle }}</h1>
+
+  <p class="govuk-body"> Details of Adyen’s fees for card payments. </p>
+
+  {{
+    govukInsetText({
+      text: "Fees are confidential and must not be shared outside your organisation."
+    })
+  }}
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+  <h2 class="govuk-heading-m">
+    <a class="govuk-link" href="{{ downloadLink }}"> Download the PDF Version </a>
+  </h2>
+
+  <p class="govuk-body"> PDF, 141KB, 2 pages </p>
+
+  <p class="govuk-body"> This file may not be accessible for users of assistive technologies. </p>
+{% endblock %}

--- a/src/views/simplified-account/settings/switch-psp/switch-to-adyen/provider-change.njk
+++ b/src/views/simplified-account/settings/switch-psp/switch-to-adyen/provider-change.njk
@@ -12,7 +12,7 @@
       href="https://gds.blog.gov.uk/2026/06/02/building-for-the-future-making-change-simple-on-gov-uk-pay/"
     >
       GDS has procured a payment provider to replace Stripe </a
-    >. This means your payment provider is changing to Adyen. We're doing everything we can to minimise disruption and
+    >. This means your payment provider is changing to Adyen. We’re doing everything we can to minimise disruption and
     make sure there is as little as possible that you need to do.
   </p>
 
@@ -80,15 +80,15 @@
 
   <h2 class="govuk-heading-m">Fees</h2>
   <p class="govuk-body">
-    <a id="download-adyen-fee-link" href="{{ feesPath }}">Information about Adyen s fees is now available</a>
+    <a id="download-adyen-fee-link" href="{{ feesPath }}">Information about Adyen’s fees is now available</a>
   </p>
 
   <p class="govuk-body">
-    Adyen's fees are similar to Stripe but are slightly different in some areas. For example, the most common type of
+    Adyen’s fees are similar to Stripe but are slightly different in some areas. For example, the most common type of
     card used on GOV.UK Pay is a UK debit card. Stripe charge a flat rate of a few pence plus a percentage of the value
     of the transaction. Adyen charge a higher flat rate but the percentage is lower. However, credit card fees, Amex
     fees, non-European card fees and chargebacks (also known as disputes) are cheaper. The exact change depends on your
-    service's transactions.
+    service’s transactions.
   </p>
 
   <h2 class="govuk-heading-m">Minor technical changes for API users</h2>
@@ -97,14 +97,14 @@
     will be quick and easy to make the necessary changes to your service.
   </p>
 
-  <h2 class="govuk-heading-m">We're looking for early adopters</h2>
+  <h2 class="govuk-heading-m">We’re looking for early adopters</h2>
   <p class="govuk-body">
     We want to work with a few services to help us make sure everything goes smoothly. You will need to commit to a few
     feedback sessions discussing any problems or concerns you have. It will not affect your ability to take payments but
-    you'll be helping us make the process smooth for everyone.
+    you’ll be helping us make the process smooth for everyone.
   </p>
   <p class="govuk-body">
-    Get in touch with us if you're interested by emailing
+    Get in touch with us if you’re interested by emailing
     <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a>
   </p>
 
@@ -114,5 +114,7 @@
     <a href="mailto:govuk-pay-support@digital.cabinet-office.gov.uk">govuk-pay-support@digital.cabinet-office.gov.uk</a>
     if you have questions about the change of provider.
   </p>
-  <p class="govuk-body"> Please do not contact Adyen or Stripe about the move send any questions or comments to us. </p>
+  <p class="govuk-body">
+    Please do not contact Adyen or Stripe about the move - send any questions or comments to us.
+  </p>
 {% endblock %}

--- a/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/adyen-fees.controller.cy.js
+++ b/test/cypress/integration/simplified-account/service-settings/switch-psp/switch-to-adyen/adyen-fees.controller.cy.js
@@ -1,0 +1,87 @@
+const userStubs = require('@test/cypress/stubs/user-stubs')
+const gatewayAccountStubs = require('@test/cypress/stubs/gateway-account-stubs')
+const { STRIPE, WORLDPAY } = require('@models/constants/payment-providers')
+const ROLES = require('@test/fixtures/roles.fixtures')
+const { STRIPE_CREDENTIAL_IN_ACTIVE_STATE } = require('@test/fixtures/credentials.fixtures')
+const GatewayAccountType = require('@models/gateway-account/gateway-account-type')
+
+const USER_EXTERNAL_ID = 'user-123-abc'
+const SERVICE_EXTERNAL_ID = 'service456def'
+const SERVICE_NAME = {
+  en: 'McDuck Enterprises',
+  cy: 'Mentrau McDuck',
+}
+const LIVE_ACCOUNT_TYPE = 'live'
+const GATEWAY_ACCOUNT_ID = 12
+
+const PROVIDER_CHANGE_TO_ADYEN = `/service/${SERVICE_EXTERNAL_ID}/account/live/settings/switch-psp/switch-to-adyen/adyen-fees`
+
+const setStubs = (opts = {}, additionalStubs = []) => {
+  cy.task('setupStubs', [
+    userStubs.getUserSuccess({
+      userExternalId: USER_EXTERNAL_ID,
+      gatewayAccountId: GATEWAY_ACCOUNT_ID,
+      serviceName: SERVICE_NAME,
+      serviceExternalId: SERVICE_EXTERNAL_ID,
+      role: ROLES[opts.role || 'admin'],
+    }),
+    gatewayAccountStubs.getAccountByServiceIdAndAccountType(
+      SERVICE_EXTERNAL_ID,
+      opts.gatewayAccountType || LIVE_ACCOUNT_TYPE,
+      {
+        gateway_account_id: GATEWAY_ACCOUNT_ID,
+        type: opts.gatewayAccountType || GatewayAccountType.LIVE,
+        payment_provider: opts.paymentProvider || STRIPE,
+        provider_switch_enabled: opts.providerSwitchEnabled || false,
+        gateway_account_credentials: [STRIPE_CREDENTIAL_IN_ACTIVE_STATE],
+      }
+    ),
+    ...additionalStubs,
+  ])
+}
+
+describe('Switch to Adyen - Adyen fees page', () => {
+  beforeEach(() => {
+    cy.setEncryptedCookies(USER_EXTERNAL_ID)
+  })
+  describe('Stripe live account', () => {
+    it('should show error page to non-admin user', () => {
+      setStubs({
+        role: 'view-and-refund',
+      })
+      cy.visit(PROVIDER_CHANGE_TO_ADYEN, { failOnStatusCode: false })
+      cy.title().should('eq', 'An error occurred - GOV.UK Pay')
+      cy.get('h1').should('contain.text', 'An error occurred')
+    })
+  })
+  describe('Stripe test account', () => {
+    it('should show page not found error to admin user', () => {
+      setStubs({
+        role: 'admin',
+        gatewayAccountType: GatewayAccountType.TEST,
+      })
+      cy.visit(PROVIDER_CHANGE_TO_ADYEN, { failOnStatusCode: false })
+      cy.title().should('contain', 'Page not found')
+    })
+    it('should show page not found error to non-admin user', () => {
+      setStubs({
+        role: 'view-and-refund',
+        gatewayAccountType: GatewayAccountType.TEST,
+      })
+      cy.visit(PROVIDER_CHANGE_TO_ADYEN, { failOnStatusCode: false })
+      cy.title().should('eq', 'Page not found - GOV.UK Pay')
+      cy.get('h1').should('contain.text', 'Page not found')
+    })
+  })
+  describe('Worldpay live account', () => {
+    it('should show error page to admin user', () => {
+      setStubs({
+        role: 'admin',
+        paymentProvider: WORLDPAY,
+      })
+      cy.visit(PROVIDER_CHANGE_TO_ADYEN, { failOnStatusCode: false })
+      cy.title().should('eq', 'Page not found - GOV.UK Pay')
+      cy.get('h1').should('contain.text', 'Page not found')
+    })
+  })
+})


### PR DESCRIPTION
## What
- Added Adyen fees page for Stripe admin users to download Adyen fees
- There is no Cypress test for the happy path, as we don't have a way to stub AWS calls for Cypress tests

### Screenshots (views have been added/changed)

<img width="662" height="431" alt="image" src="https://github.com/user-attachments/assets/a647fb7b-5cdd-4ce4-9c8f-d3aa45b22727" />
