### PR TITLE
PP-15481 Update payment status for disputes lost to user

### DIFF
--- a/src/views/simplified-account/services/transactions/detail/partials/_details.njk
+++ b/src/views/simplified-account/services/transactions/detail/partials/_details.njk
@@ -33,7 +33,7 @@
         text: 'Payment status'
       },
       value: {
-        text: transaction._locals.formatted.status
+        text: dispute._locals.formatted.status if (transaction.disputed and dispute and dispute.isDisputeLost()) else transaction._locals.formatted.status
       }
     }, {
       key: {

--- a/test/cypress/integration/simplified-account/transactions/transaction-detail/transaction-detail-disputes.cy.ts
+++ b/test/cypress/integration/simplified-account/transactions/transaction-detail/transaction-detail-disputes.cy.ts
@@ -86,6 +86,20 @@ describe('Transaction details page', () => {
           .should('contain.text', 'You cannot refund this payment because it is being disputed.')
       })
 
+      it('should show the payment status', () => {
+        cy.visit(TRANSACTION_URL)
+
+        cy.get('.govuk-summary-list')
+          .eq(0)
+          .within(() => {
+            cy.get('.govuk-summary-list__key')
+              .contains('Payment status')
+              .next()
+              .should('have.class', 'govuk-summary-list__value')
+              .should('contain.text', 'Success')
+          })
+      })
+
       it('should display the correct dispute information', () => {
         cy.visit(TRANSACTION_URL)
 
@@ -163,6 +177,20 @@ describe('Transaction details page', () => {
           .should('contain.text', 'You cannot refund this payment because it is being disputed.')
       })
 
+      it('should show the payment status', () => {
+        cy.visit(TRANSACTION_URL)
+
+        cy.get('.govuk-summary-list')
+          .eq(0)
+          .within(() => {
+            cy.get('.govuk-summary-list__key')
+              .contains('Payment status')
+              .next()
+              .should('have.class', 'govuk-summary-list__value')
+              .should('contain.text', 'Success')
+          })
+      })
+
       it('should display the correct dispute information', () => {
         cy.visit(TRANSACTION_URL)
 
@@ -236,6 +264,20 @@ describe('Transaction details page', () => {
           .next()
           .should('have.class', 'govuk-button')
           .should('contain.text', 'Refund payment')
+      })
+
+      it('should show the payment status', () => {
+        cy.visit(TRANSACTION_URL)
+
+        cy.get('.govuk-summary-list')
+          .eq(0)
+          .within(() => {
+            cy.get('.govuk-summary-list__key')
+              .contains('Payment status')
+              .next()
+              .should('have.class', 'govuk-summary-list__value')
+              .should('contain.text', 'Success')
+          })
       })
 
       it('should display the correct dispute information', () => {
@@ -316,6 +358,20 @@ describe('Transaction details page', () => {
             'contain.text',
             'You cannot refund this payment because it was disputed and the paying user won the dispute.'
           )
+      })
+
+      it('should show the payment status', () => {
+        cy.visit(TRANSACTION_URL)
+
+        cy.get('.govuk-summary-list')
+          .eq(0)
+          .within(() => {
+            cy.get('.govuk-summary-list__key')
+              .contains('Payment status')
+              .next()
+              .should('have.class', 'govuk-summary-list__value')
+              .should('contain.text', 'Dispute lost to user')
+          })
       })
 
       it('should display the correct dispute information', () => {


### PR DESCRIPTION
## What

PP-15481

 - update the displayed "Payment status" value to "Dispute lost to user" for payments which have been disputed and the dispute lost to the user
 - keep the displayed payment status as the normal status in all other cases
 - this only updates the Transaction Details page, the payment status displayed in the Transactions list still shows as "Success" for the disputed payment
 - this is in line with the existing Transactions pages

### Screenshots (views have been added/changed)
Screenshot is taken from Cypress tests, and so based on mock data. This data should be correct.

<img width="662" height="380" alt="Screenshot 2026-06-19 at 11 40 15" src="https://github.com/user-attachments/assets/e255ced1-0d4f-4b92-8775-70250b10cf98" />

