### PR TITLE
PP-15380 Update dashboard links when transactions feature flag is enabled

### DIFF
--- a/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
+++ b/src/controllers/simplified-account/services/dashboard/dashboard.controller.ts
@@ -1,7 +1,12 @@
 import { response } from '@utils/response'
 import { ServiceRequest, ServiceResponse } from '@utils/types/express'
 import { dashboardTransactionSummary } from '@services/transactions.service'
-import { DT_FULL, getPeriodUKDateTimeRange, Period } from '@utils/simplified-account/services/dashboard/datetime-utils'
+import {
+  DT_FULL,
+  getPeriodUKDateTimeRange,
+  Period,
+  TRANSACTION_FILTER_PERIODS,
+} from '@utils/simplified-account/services/dashboard/datetime-utils'
 import formatAccountPathsFor from '@utils/format-account-paths-for'
 import paths from '@root/paths'
 import formatServicePathsFor from '@utils/format-service-paths-for'
@@ -22,10 +27,11 @@ import GatewayAccountType from '@models/gateway-account/gateway-account-type'
 const logger = createLogger(__filename)
 
 async function get(req: ServiceRequest, res: ServiceResponse) {
-  const currentPeriod = req.query.period as Period
+  const currentPeriod = (req.query.period as Period) ?? Period.TODAY
   const { start, end } = getPeriodUKDateTimeRange(currentPeriod)
 
   const searchParams = new URLSearchParams()
+  searchParams.append('dateFilter', TRANSACTION_FILTER_PERIODS.has(currentPeriod) ? currentPeriod : 'custom-range')
 
   if (start && end) {
     searchParams.append('fromDate', start.toFormat('dd/MM/yyyy'))
@@ -33,6 +39,8 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
     searchParams.append('toDate', end.toFormat('dd/MM/yyyy'))
     searchParams.append('toTime', end.toFormat('HH:mm:ss'))
   }
+
+  req.serviceView.links.transactions.withDefaultSearchParams(searchParams)
 
   const transactionsPeriodQueryParams = searchParams.toString()
 

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -78,6 +78,8 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
 
   req.session.transactionFilters = req.url.split('?')[1] || ''
 
+  console.log(transactionSearchParams)
+
   return response(req, res, 'simplified-account/transactions/index', {
     results,
     isBST: isBritishSummerTime(),

--- a/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
+++ b/src/controllers/simplified-account/services/transactions/transaction-list.controller.ts
@@ -78,8 +78,6 @@ async function get(req: ServiceRequest, res: ServiceResponse) {
 
   req.session.transactionFilters = req.url.split('?')[1] || ''
 
-  console.log(transactionSearchParams)
-
   return response(req, res, 'simplified-account/transactions/index', {
     results,
     isBST: isBritishSummerTime(),

--- a/src/models/service-view/ServiceView.class.ts
+++ b/src/models/service-view/ServiceView.class.ts
@@ -52,7 +52,7 @@ export class ServiceView {
   private readonly service: Service
   private readonly accountType: string
 
-  private readonly links: ServiceViewLinksGenerator
+  public readonly links: ServiceViewLinksGenerator
 
   constructor(statusTag: StatusTag, displayTag: DisplayTag, service: Service, accountType: string) {
     this.statusTag = statusTag

--- a/src/models/service-view/ServiceViewLinksGenerator.class.ts
+++ b/src/models/service-view/ServiceViewLinksGenerator.class.ts
@@ -18,14 +18,14 @@ export class ServiceViewLinksGenerator {
 
 export class ServiceTransactionLinks {
   private readonly serviceViewGenerator: ServiceViewLinksGenerator
-  public defaultSearches?: eTransactionDefaultSearchLinks
+  public defaultSearches?: TransactionDefaultSearchLinks
 
   constructor(serviceViewGenerator: ServiceViewLinksGenerator) {
     this.serviceViewGenerator = serviceViewGenerator
   }
 
   withDefaultSearchParams(searchParams: URLSearchParams) {
-    this.defaultSearches = new eTransactionDefaultSearchLinks(this.serviceViewGenerator, searchParams)
+    this.defaultSearches = new TransactionDefaultSearchLinks(this.serviceViewGenerator, searchParams)
   }
 
   get downloadCsv() {
@@ -37,7 +37,7 @@ export class ServiceTransactionLinks {
   }
 }
 
-class eTransactionDefaultSearchLinks {
+class TransactionDefaultSearchLinks {
   private readonly serviceViewGenerator: ServiceViewLinksGenerator
   private readonly searchParams: URLSearchParams
 
@@ -65,7 +65,7 @@ class eTransactionDefaultSearchLinks {
         this.serviceViewGenerator.serviceExternalId,
         this.serviceViewGenerator.accountType
       ) +
-      'state=refund_success&' +
+      '?state=refund_success&' +
       this.searchParams.toString()
     )
   }
@@ -77,7 +77,7 @@ class eTransactionDefaultSearchLinks {
         this.serviceViewGenerator.serviceExternalId,
         this.serviceViewGenerator.accountType
       ) +
-      'state=success&state=refund_success&' +
+      '?state=success&state=refund_success&' +
       this.searchParams.toString()
     )
   }

--- a/src/models/service-view/ServiceViewLinksGenerator.class.ts
+++ b/src/models/service-view/ServiceViewLinksGenerator.class.ts
@@ -16,10 +16,16 @@ export class ServiceViewLinksGenerator {
   }
 }
 
-class ServiceTransactionLinks {
+export class ServiceTransactionLinks {
   private readonly serviceViewGenerator: ServiceViewLinksGenerator
+  public defaultSearches?: eTransactionDefaultSearchLinks
+
   constructor(serviceViewGenerator: ServiceViewLinksGenerator) {
     this.serviceViewGenerator = serviceViewGenerator
+  }
+
+  withDefaultSearchParams(searchParams: URLSearchParams) {
+    this.defaultSearches = new eTransactionDefaultSearchLinks(this.serviceViewGenerator, searchParams)
   }
 
   get downloadCsv() {
@@ -27,6 +33,52 @@ class ServiceTransactionLinks {
       paths.simplifiedAccount.transactions.downloadCsv,
       this.serviceViewGenerator.serviceExternalId,
       this.serviceViewGenerator.accountType
+    )
+  }
+}
+
+class eTransactionDefaultSearchLinks {
+  private readonly serviceViewGenerator: ServiceViewLinksGenerator
+  private readonly searchParams: URLSearchParams
+
+  constructor(serviceViewGenerator: ServiceViewLinksGenerator, searchParams: URLSearchParams) {
+    this.serviceViewGenerator = serviceViewGenerator
+    this.searchParams = searchParams
+  }
+
+  get successfulPayments(): string {
+    return (
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.transactions.index,
+        this.serviceViewGenerator.serviceExternalId,
+        this.serviceViewGenerator.accountType
+      ) +
+      '?state=success&' +
+      this.searchParams.toString()
+    )
+  }
+
+  get successfulRefunds(): string {
+    return (
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.transactions.index,
+        this.serviceViewGenerator.serviceExternalId,
+        this.serviceViewGenerator.accountType
+      ) +
+      'state=refund_success&' +
+      this.searchParams.toString()
+    )
+  }
+
+  get netIncome(): string {
+    return (
+      formatServiceAndAccountPathsFor(
+        paths.simplifiedAccount.transactions.index,
+        this.serviceViewGenerator.serviceExternalId,
+        this.serviceViewGenerator.accountType
+      ) +
+      'state=success&state=refund_success&' +
+      this.searchParams.toString()
     )
   }
 }

--- a/src/utils/simplified-account/services/dashboard/datetime-utils.ts
+++ b/src/utils/simplified-account/services/dashboard/datetime-utils.ts
@@ -1,6 +1,16 @@
 import { DateTime, DateTimeFormatOptions } from 'luxon'
 import { TimeConstants } from '@utils/time/time-constants'
 
+export const Period: Record<string, Period> = {
+  TODAY: 'today',
+  YESTERDAY: 'yesterday',
+  PREVIOUS_SEVEN_DAYS: 'previous-seven-days',
+  PREVIOUS_THIRTY_DAYS: 'previous-thirty-days',
+  PREVIOUS_MONTH: 'previous-month',
+  LAST_12_MONTHS: 'last-12-months',
+  ALL_TIME: 'all-time',
+}
+
 export type Period =
   | 'today'
   | 'yesterday'
@@ -9,6 +19,14 @@ export type Period =
   | 'previous-month'
   | 'last-12-months'
   | 'all-time'
+
+export const TRANSACTION_FILTER_PERIODS: Set<Period> = new Set<Period>([
+  Period.TODAY,
+  Period.YESTERDAY,
+  Period.PREVIOUS_MONTH,
+  Period.TODAY,
+  Period.ALL_TIME,
+])
 
 interface DateTimeRange {
   start: DateTime<true> | undefined

--- a/src/views/simplified-account/services/dashboard/partials/_activity.njk
+++ b/src/views/simplified-account/services/dashboard/partials/_activity.njk
@@ -1,110 +1,133 @@
 <form method="get" novalidate>
-  {{ govukSelect({
-    formGroup: {
-      classes: "dashboard-date-range-container govuk-!-margin-right-2"
-    },
-    classes: "dashboard-date-range-container__select",
-    id: "activity-period",
-    name: "period",
-    label: {
-      text: "Select a date range",
-      classes: "govuk-visually-hidden"
-    },
-    items: [
-      {
-        value: "today",
-        text: "Today",
-        selected: currentPeriod === 'today'
+  {{
+    govukSelect({
+      formGroup: {
+        classes: "dashboard-date-range-container govuk-!-margin-right-2"
       },
-      {
-        value: "yesterday",
-        text: "Yesterday",
-        selected: currentPeriod === 'yesterday'
+      classes: "dashboard-date-range-container__select",
+      id: "activity-period",
+      name: "period",
+      label: {
+        text: "Select a date range",
+        classes: "govuk-visually-hidden"
       },
-      {
-        value: "previous-seven-days",
-        text: "Previous 7 days",
-        selected: currentPeriod === 'previous-seven-days'
-      },
-      {
-        value: "previous-thirty-days",
-        text: "Previous 30 days",
-        selected: currentPeriod === 'previous-thirty-days'
-      }
-    ]
-  }) }}
+      items: [
+        {
+          value: "today",
+          text: "Today",
+          selected: currentPeriod === 'today'
+        },
+        {
+          value: "yesterday",
+          text: "Yesterday",
+          selected: currentPeriod === 'yesterday'
+        },
+        {
+          value: "previous-seven-days",
+          text: "Previous 7 days",
+          selected: currentPeriod === 'previous-seven-days'
+        },
+        {
+          value: "previous-thirty-days",
+          text: "Previous 30 days",
+          selected: currentPeriod === 'previous-thirty-days'
+        }
+      ]
+    })
+  }}
 
-  {{ govukButton({
-    classes: "govuk-button--secondary dashboard-date-range__select",
-    text: "Update"
-  }) }}
+  {{
+    govukButton({
+      classes: "govuk-button--secondary dashboard-date-range__select",
+      text: "Update"
+    })
+  }}
 </form>
 
 <div class="govuk-grid-row" data-click-events data-click-category="Dashboard" data-click-action="Activity link clicked">
-{% if not activity.error %}
-  <article class="dashboard-total-group govuk-grid-column-one-third">
-    <header class="dashboard-total-group__heading">
-      <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{ links.activity.payments }}" title="View successful payment transactions for chosen time period">
-          Successful payments
-        </a>
-      </h2>
-    </header>
-    <dl class="dashboard-total-group__values dashboard-total-group__values--blue">
-      <dt class="govuk-visually-hidden">Count</dt>
-      <dd class="dashboard-total-group__count">{{ activity.successfulPayments.count }}</dd>
-      <dt class="govuk-visually-hidden">Amount</dt>
-      <dd class="dashboard-total-group__amount">{{ activity.successfulPayments.totalInPence | penceToPoundsWithCurrency }}</dd>
-    </dl>
-  </article>
-  <article class="dashboard-total-group govuk-grid-column-one-third">
-    <header class="dashboard-total-group__heading">
-      <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{ links.activity.refunds }}" title="View refunded transactions for chosen time period">
-          Successful refunds
-        </a>
-      </h2>
-    </header>
-    <dl class="dashboard-total-group__values dashboard-total-group__values--red">
-      <dt class="govuk-visually-hidden">Count</dt>
-      <dd class="dashboard-total-group__count">{{ activity.refundedPayments.count }}</dd>
-      <dt class="govuk-visually-hidden">Amount</dt>
-      <dd class="dashboard-total-group__amount">{{ activity.refundedPayments.totalInPence | penceToPoundsWithCurrency }}</dd>
-    </dl>
-  </article>
-  <article class="dashboard-total-group govuk-grid-column-one-third">
-    <header class="dashboard-total-group__heading">
-      <h2 class="dashboard-total-group__title">
-        <a class="govuk-link" href="{{ links.activity.net }}" title="View successful payments and refunded transactions for chosen time period">
-          Net income
-        </a>
-      </h2>
-    </header>
-    <dl class="dashboard-total-group__values">
-      <dt class="govuk-visually-hidden">Amount</dt>
-      <dd class="dashboard-total-group__amount">{{ activity.netIncome.totalInPence | penceToPoundsWithCurrency }}</dd>
-    </dl>
+  {% if not activity.error %}
+    <article class="dashboard-total-group govuk-grid-column-one-third">
+      <header class="dashboard-total-group__heading">
+        <h2 class="dashboard-total-group__title">
+          <a
+            class="govuk-link"
+            href="{{ serviceView.links.transactions.defaultSearches.successfulPayments if EnvironmentFeatures.isEnabled('transactions') else links.activity.payments }}"
+            title="View successful payment transactions for chosen time period"
+          >
+            Successful payments
+          </a>
+        </h2>
+      </header>
+      <dl class="dashboard-total-group__values dashboard-total-group__values--blue">
+        <dt class="govuk-visually-hidden">Count</dt>
+        <dd class="dashboard-total-group__count">{{ activity.successfulPayments.count }}</dd>
+        <dt class="govuk-visually-hidden">Amount</dt>
+        <dd class="dashboard-total-group__amount"
+          >{{ activity.successfulPayments.totalInPence | penceToPoundsWithCurrency }}</dd
+        >
+      </dl>
+    </article>
+    <article class="dashboard-total-group govuk-grid-column-one-third">
+      <header class="dashboard-total-group__heading">
+        <h2 class="dashboard-total-group__title">
+          <a
+            class="govuk-link"
+            href="{{ serviceView.links.transactions.defaultSearches.successfulRefunds if EnvironmentFeatures.isEnabled('transactions') else links.activity.refunds }}"
+            title="View refunded transactions for chosen time period"
+          >
+            Successful refunds
+          </a>
+        </h2>
+      </header>
+      <dl class="dashboard-total-group__values dashboard-total-group__values--red">
+        <dt class="govuk-visually-hidden">Count</dt>
+        <dd class="dashboard-total-group__count">{{ activity.refundedPayments.count }}</dd>
+        <dt class="govuk-visually-hidden">Amount</dt>
+        <dd class="dashboard-total-group__amount"
+          >{{ activity.refundedPayments.totalInPence | penceToPoundsWithCurrency }}</dd
+        >
+      </dl>
+    </article>
+    <article class="dashboard-total-group govuk-grid-column-one-third">
+      <header class="dashboard-total-group__heading">
+        <h2 class="dashboard-total-group__title">
+          <a
+            class="govuk-link"
+            href="{{ serviceView.links.transactions.defaultSearches.netIncome if EnvironmentFeatures.isEnabled('transactions') else links.activity.net }}"
+            title="View successful payments and refunded transactions for chosen time period"
+          >
+            Net income
+          </a>
+        </h2>
+      </header>
+      <dl class="dashboard-total-group__values">
+        <dt class="govuk-visually-hidden">Amount</dt>
+        <dd class="dashboard-total-group__amount">{{ activity.netIncome.totalInPence | penceToPoundsWithCurrency }}</dd>
+      </dl>
 
-    {% set detailsHTML %}
-      <p>Net income was calculated by subtracting the successful refunds from the successful payments for {{ humanDates.start }} to {{ humanDates.end }}</p>
-    {% endset %}
+      {% set detailsHTML %}
+        <p
+          >Net income was calculated by subtracting the successful refunds from the successful payments for
+          {{ humanDates.start }} to {{ humanDates.end }}</p
+        >
+      {% endset %}
 
-    {{
-      govukDetails({
-        summaryText: "How these numbers are calculated",
-        classes: "dashboard-total-explainer",
-        html: detailsHTML
-      })
-    }}
-  </article>
-{% else %}
-  <article class="dashboard-total-group govuk-grid-column-one-half">
-    <header class="dashboard-total-group__heading">
-      <h2 class="dashboard-total-group__title">Error fetching totals</h2>
-    </header>
-    <div class="dashboard-total-group__values dashboard-total-group__values--red">
-      <span class="govuk-body govuk-!-margin-0">Transaction activity data cannot be retrieved at this time.</span>
-    </div>
-  </article>
-{% endif %}
+      {{
+        govukDetails({
+          summaryText: "How these numbers are calculated",
+          classes: "dashboard-total-explainer",
+          html: detailsHTML
+        })
+      }}
+    </article>
+  {% else %}
+    <article class="dashboard-total-group govuk-grid-column-one-half">
+      <header class="dashboard-total-group__heading">
+        <h2 class="dashboard-total-group__title">Error fetching totals</h2>
+      </header>
+      <div class="dashboard-total-group__values dashboard-total-group__values--red">
+        <span class="govuk-body govuk-!-margin-0">Transaction activity data cannot be retrieved at this time.</span>
+      </div>
+    </article>
+  {% endif %}
 </div>

--- a/test/fixtures/service/service.fixture.ts
+++ b/test/fixtures/service/service.fixture.ts
@@ -18,7 +18,7 @@ export class ServiceFixture {
   readonly defaultBillingAddressCountry?: string
   readonly takesPaymentsOverPhone: boolean
 
-  constructor(overrides?: Partial<ServiceFixture>) {
+  constructor(...overrides: Partial<ServiceFixture>[]) {
     this.id = 1
     this.externalId = 'service-external-id-123-abc'
     this.name = 'Power Plant Safety Inspection'
@@ -34,9 +34,9 @@ export class ServiceFixture {
     this.agentInitiatedMotoEnabled = false
     this.takesPaymentsOverPhone = false
 
-    if (overrides) {
-      Object.assign(this, overrides)
-    }
+    overrides?.forEach((overrideValues) => {
+      Object.assign(this, overrideValues)
+    })
   }
 
   toServiceData(): ServiceData {

--- a/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
+++ b/test/test-helpers/simplified-account/controllers/ControllerTestBuilder.class.js
@@ -1,6 +1,9 @@
 const sinon = require('sinon')
 const _ = require('lodash')
 const proxyquire = require('proxyquire')
+const Service = require('@models/service/Service.class')
+const GatewayAccount = require('@models/gateway-account/GatewayAccount.class')
+const { ServiceView } = require('@models/service-view/ServiceView.class')
 
 module.exports = class ControllerTestBuilder {
   constructor(controllerPath) {
@@ -137,8 +140,17 @@ module.exports = class ControllerTestBuilder {
         if (typeof fn !== 'function') {
           throw new Error(`No function found for method '${method}'${index !== undefined ? ` at index ${index}` : ''}`)
         }
-        const result = await fn(this.nextReq || this.req, this.nextRes || this.res, this.next)
         const currentReq = this.nextReq || this.req
+        if (
+          currentReq.service &&
+          currentReq.service instanceof Service &&
+          currentReq.account &&
+          currentReq.account instanceof GatewayAccount &&
+          !currentReq.serviceView
+        ) {
+          currentReq.serviceView = ServiceView.determineFor(currentReq.service, currentReq.account)
+        }
+        const result = await fn(currentReq, this.nextRes || this.res, this.next)
         const currentRes = this.nextRes || this.res
         this.nextReq = this.nextRes = null
         return { result, req: currentReq, res: currentRes }


### PR DESCRIPTION
## What

PP-15380

 - update the links to transactions pages on the service dashboard to link to new transactions list when `transactions` feature flag is enabled
 - propagate selected search period to Transactions search for consistency
 - explicitly set default activity period to `today` for service activity on dashboard so this can be propagated to the Transactions search
